### PR TITLE
Adding schema key sorting

### DIFF
--- a/drf_spectacular/app_settings.py
+++ b/drf_spectacular/app_settings.py
@@ -8,6 +8,7 @@ SPECTACULAR_DEFAULTS = {
         'drf_spectacular.auth.TokenAuthenticationScheme',
     ],
     'SCHEMA_PATH_PREFIX': r'',
+    'ENABLE_SCHEMA_KEY_SORTING': True
 }
 
 IMPORT_STRINGS = [

--- a/drf_spectacular/renderers.py
+++ b/drf_spectacular/renderers.py
@@ -1,5 +1,8 @@
 import yaml
+from django.conf import settings
 from rest_framework.renderers import OpenAPIRenderer
+
+enable_schema_key_sorting = settings.SPECTACULAR_SETTINGS['ENABLE_SCHEMA_KEY_SORTING']
 
 
 class NoAliasOpenAPIRenderer(OpenAPIRenderer):
@@ -11,4 +14,4 @@ class NoAliasOpenAPIRenderer(OpenAPIRenderer):
             def ignore_aliases(self, data):
                 return True
 
-        return yaml.dump(data, default_flow_style=False, sort_keys=False, Dumper=Dumper).encode('utf-8')
+        return yaml.dump(data, default_flow_style=False, sort_keys=enable_schema_key_sorting, Dumper=Dumper).encode('utf-8')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def pytest_configure():
             'django.contrib.auth.hashers.MD5PasswordHasher',
             'django.contrib.auth.hashers.CryptPasswordHasher',
         ),
+        SPECTACULAR_SETTINGS={'ENABLE_SCHEMA_KEY_SORTING': False}
     )
 
     try:


### PR DESCRIPTION


In my case, the schema in swagger-ui display looks unsorted. This is inconvenient to use.
![image](https://user-images.githubusercontent.com/6458407/76496293-c3e24e80-6449-11ea-9774-ad80b9b6ea29.png)
This is a problem for schema users.


If sorted, then everything looks good and it’s convenient to use
![image](https://user-images.githubusercontent.com/6458407/76496170-7cf45900-6449-11ea-8491-8a4ff80e9e53.png)
