### PR TITLE
Fix queryset call

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -393,7 +393,8 @@ class AutoSchema(ViewInspector):
             return build_array_type(self._map_serializer_field(method, field.child_relation))
 
         if isinstance(field, serializers.PrimaryKeyRelatedField):
-            if field.queryset:
+            field_queryset = getattr(field, 'queryset', None)
+            if field_queryset is not None:
                 return self._map_model_field(field.queryset.model._meta.pk)
             else:
                 # read_only fields to not have a queryset by design.


### PR DESCRIPTION
This parameter cannot be called, as this causes a query to the database

In my case, it caused such problems:
```
WARNING: type hint for function "grade" is unknown. defaulting to string.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedTable: relation "comments" does not exist
LINE 1: ...files_user"."karma", "profiles_user"."extra" FROM "comments"...
                                                             ^


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 328, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 369, in execute
    output = self.handle(*args, **options)
  File "/opt/drf_spectacular/management/commands/spectacular.py", line 33, in handle
    schema = generator.get_schema(request=None, public=True)
  File "/opt/drf_spectacular/openapi.py", line 111, in get_schema
    'paths': self.parse(None if public else request),
  File "/opt/drf_spectacular/openapi.py", line 81, in parse
    operation = view.schema.get_operation(path, method, self.registry)
  File "/opt/drf_spectacular/utils.py", line 106, in get_operation
    return super().get_operation(path, method, registry)
  File "/opt/drf_spectacular/openapi.py", line 149, in get_operation
    request_body = self._get_request_body(path, method)
  File "/opt/drf_spectacular/openapi.py", line 683, in _get_request_body
    component = self.resolve_serializer(method, serializer)
  File "/opt/drf_spectacular/openapi.py", line 803, in resolve_serializer
    component.schema = self._map_serializer(method, serializer)
  File "/opt/drf_spectacular/openapi.py", line 528, in _map_serializer
    return self._map_concrete_serializer(method, serializer)
  File "/opt/drf_spectacular/openapi.py", line 564, in _map_concrete_serializer
    schema = self._map_serializer_field(method, field)
  File "/opt/drf_spectacular/openapi.py", line 397, in _map_serializer_field
    if field_queryset:
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 280, in __bool__
    self._fetch_all()
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 1261, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 57, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1151, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 100, in execute
    return super().execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 68, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 77, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: relation "comments" does not exist
LINE 1: ...files_user"."karma", "profiles_user"."extra" FROM "comments"...
                                                             ^                                                            ^
```