### PR TITLE
Support required paramter in Query Serializer

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -173,10 +173,12 @@ class AutoSchema(ViewInspector):
                 # explode serializer into separate parameters. defaults to QUERY location
                 mapped = self._map_serializer(method, parameter)
                 for property_name, property_schema in mapped['properties'].items():
+                    required = property_name in mapped.get('required', [])
                     result.append(build_parameter_type(
                         name=property_name,
                         schema=property_schema,
                         location=OpenApiParameter.QUERY,
+                        required=required
                     ))
             else:
                 warn(f'could not resolve parameter annotation {parameter}. skipping.')

--- a/tests/test_extend_schema.py
+++ b/tests/test_extend_schema.py
@@ -38,7 +38,7 @@ class InlineSerializer(serializers.Serializer):
 
 class QuerySerializer(serializers.Serializer):
     stars = serializers.IntegerField(min_value=1, max_value=5, help_text='filter by rating stars')
-    contains = serializers.CharField(min_length=3, max_length=10, help_text='filter by containing string')
+    contains = serializers.CharField(min_length=3, max_length=10, help_text='filter by containing string', required=False)
 
 
 class ErrorDetailSerializer(serializers.Serializer):

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -161,6 +161,7 @@ paths:
           maximum: 5
           minimum: 1
           description: filter by rating stars
+        required: true
       tags:
       - doesitall
       security:
@@ -284,4 +285,3 @@ components:
           minLength: 3
       required:
       - stars
-      - contains


### PR DESCRIPTION
Added support for required and optional parameters in Query Serializer.

This will help to better understand the schema.