### PR TITLE
Add test when simple view is interpreted as list view

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from django.urls import path
 
 from drf_spectacular.validation import validate_schema
 
@@ -20,13 +21,19 @@ def assert_schema(schema, reference_file):
     validate_schema(schema)
 
 
-def generate_schema(route, viewset):
+def generate_schema(route, viewset=None, view=None):
     from rest_framework import routers
     from drf_spectacular.openapi import SchemaGenerator
 
-    router = routers.SimpleRouter()
-    router.register(route, viewset, basename=route)
-    generator = SchemaGenerator(patterns=router.urls)
+    patterns = []
+    if viewset:
+        router = routers.SimpleRouter()
+        router.register(route, viewset, basename=route)
+        patterns = router.urls
+    if view:
+        patterns = [path(route, view.as_view())]
+
+    generator = SchemaGenerator(patterns=patterns)
     return generator.get_schema(request=None, public=True)
 
 

--- a/tests/test_extend_schema.py
+++ b/tests/test_extend_schema.py
@@ -4,6 +4,7 @@ from django.utils.http import urlsafe_base64_encode
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.types import OpenApiTypes
@@ -168,8 +169,27 @@ with mock.patch('rest_framework.settings.api_settings.DEFAULT_SCHEMA_CLASS', Aut
             return Response([])
 
 
-def test_extend_schema(no_warnings):
+with mock.patch('rest_framework.settings.api_settings.DEFAULT_SCHEMA_CLASS', AutoSchema):
+    class TestApiView(APIView):
+        authentication_classes = []
+
+        @extend_schema(
+            parameters=[OpenApiParameter('id', OpenApiTypes.INT, OpenApiParameter.PATH)],
+            responses={200: AlphaSerializer},
+        )
+        def get(self, request):
+            return Response([])
+
+
+def test_extend_schema_viewset(no_warnings):
     assert_schema(
-        generate_schema('doesitall', DoesItAllViewset),
+        generate_schema('doesitall', viewset=DoesItAllViewset),
         'tests/test_extend_schema.yml'
+    )
+
+
+def test_extend_schema_view(no_warnings):
+    assert_schema(
+        generate_schema('{id}/test/', view=TestApiView),
+        'tests/test_extend_schema_view.yml'
     )

--- a/tests/test_extend_schema_view.yml
+++ b/tests/test_extend_schema_view.yml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /{id}/test/:
+    get:
+      operationId: test_retrieve
+      description: ''
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - test
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Alpha'
+          description: ''
+  schemas:
+    Alpha:
+      type: object
+      properties:
+        field_a:
+          type: string
+        field_b:
+          type: integer
+      required:
+      - field_a
+      - field_b


### PR DESCRIPTION
Spectacular uses `is_list_view` to determine whether view is listing or not. If it is then response is wrapped in array and operation ID has suffix `_list`.

`is_list_view` has some heuristics, and the last of them is to explode route and check if the last part is dynamic parameter like `{id}`.

So, if you have APIView with route that doesn't end with such parameter, you will end up with response serializer wrapped with array just because of the failed heuristic.