### PR TITLE
Pagination problem 

### DIFF
--- a/tests/test_extend_schema_paginator.yml
+++ b/tests/test_extend_schema_paginator.yml
@@ -1,0 +1,74 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /doesitallwithpaginator/:
+    get:
+      operationId: doesitallwithpaginator_list
+      description: ''
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - doesitallwithpaginator
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiListBeta'
+          description: ''
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: Session
+    basicAuth:
+      type: http
+      scheme: basic
+  schemas:
+    ApiListBeta:
+      type: object
+      properties:
+        status:
+          enum:
+          - ok
+          - error
+          type: string
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Beta'
+      required:
+      - status
+      - data
+    Beta:
+      type: object
+      properties:
+        field_a:
+          type: string
+        field_b:
+          type: integer
+        field_c:
+          type: object
+          additionalProperties: {}
+      required:
+      - field_a
+      - field_b
+      - field_c


### PR DESCRIPTION
There is a problem in my project
In the method for getting the list, I do not use the pagination class, but I use its logic inside to implement my response

In the case of using the library, I always get output based on the pagination class
Example:

Current response
![image](https://user-images.githubusercontent.com/6458407/79139702-6f6f1d80-7dbf-11ea-8a69-d1fa74c6e0c9.png)


*Correct response should be*
![image](https://user-images.githubusercontent.com/6458407/79139618-4b134100-7dbf-11ea-8be9-3b1de4f177d5.png)

Probably the problem is that the schema analyzer is "too smart". Perhaps this could be fixed, for example, if  pass a special parameter to extend_schema. For example
```python
@extend_schema(pagination=False)
```
I also want to say that drf_yasg package gives the correct schema
Maybe the problem is somewhere in the schema analyzer logic
