### PR TITLE
WIP: AutoSchema: Inherit DRF AutoSchema

### DIFF
--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -161,8 +161,10 @@ components:
           minimum: -1000
         field_file:
           type: string
+          format: binary
         field_img:
           type: string
+          format: binary
         field_date:
           type: string
           format: date

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ ignore =
 max-line-length = 120
 
 [testenv]
-commands = ./runtests.py --fast --cov=drf_spectacular --cov=tests
+commands = ./runtests.py {posargs:--fast --cov=drf_spectacular --cov=tests}
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 passenv =


### PR DESCRIPTION
Replace custom _map_basic_serializer with _map_field,
and invoke super _map_serializer as a fallback.

DRF AutoSchema PR 7257 makes all of these fields public,
so Spectacular AutoSchema should implement them and use
them when appropriate for interoperability.

Related to https://github.com/tfranzel/drf-spectacular/issues/31
Related to https://github.com/tfranzel/drf-spectacular/issues/45