### PR TITLE
Fix getting default parameter for `MultipleChoiceField`

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -576,7 +576,10 @@ class AutoSchema(ViewInspector):
             if field.allow_null:
                 schema['nullable'] = True
             if field.default is not None and field.default != empty and not callable(field.default):
-                schema['default'] = field.to_representation(field.default)
+                default = field.to_representation(field.default)
+                if isinstance(default, set):
+                    default = list(default)
+                schema['default'] = default
             if field.help_text:
                 schema['description'] = str(field.help_text)
             self._map_field_validators(field, schema)

--- a/tests/test_extend_schema.py
+++ b/tests/test_extend_schema.py
@@ -46,6 +46,10 @@ class QuerySerializer(serializers.Serializer):
     contains = serializers.CharField(
         min_length=3, max_length=10, help_text='filter by containing string', required=False
     )
+    order_by = serializers.MultipleChoiceField(
+        choices=['a', 'b'],
+        default=['a'],
+    )
 
 
 class ErrorDetailSerializer(serializers.Serializer):
@@ -90,7 +94,7 @@ with mock.patch('rest_framework.settings.api_settings.DEFAULT_SCHEMA_CLASS', Aut
                 OpenApiParameter(
                     'test_mode', bool, location=OpenApiParameter.HEADER, enum=[True, False],
                     description='creation will be in the sandbox',
-                ),
+                )
             ],
             description='this weird endpoint needs some explaining',
             deprecated=True,

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -185,6 +185,17 @@ paths:
         schema:
           $ref: '#/components/schemas/Query'
       - in: query
+        name: order_by
+        schema:
+          type: array
+          items:
+            enum:
+            - a
+            - b
+            type: string
+          default:
+          - a
+      - in: query
         name: stars
         schema:
           type: integer
@@ -317,6 +328,15 @@ components:
           description: filter by containing string
           maxLength: 10
           minLength: 3
+        order_by:
+          type: array
+          items:
+            enum:
+            - a
+            - b
+            type: string
+          default:
+          - a
       required:
       - stars
     FieldLEnum:


### PR DESCRIPTION
By default field gives `default` parameter as `set` type. This type is not supported by json schema