### PR TITLE
Add nullable property for OBJECT

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -352,6 +352,8 @@ class ComponentRegistry:
         output = defaultdict(dict)
         # build tree from flat registry
         for component in self._components.values():
+            if getattr(component.object, 'allow_null', None):
+                component.schema['nullable'] = True
             output[component.type][component.name] = component.schema
         # add/override extra components
         for extra_type, extra_component_dict in extra_components.items():

--- a/tests/test_extend_schema.py
+++ b/tests/test_extend_schema.py
@@ -62,7 +62,7 @@ class ErrorDetailSerializer(serializers.Serializer):
     def get_field_i(self, object):
         return '2020-03-06 20:54:00.104248'  # pragma: no cover
 
-    @extend_schema_field(InlineSerializer)
+    @extend_schema_field(InlineSerializer(allow_null=True))
     def get_field_j(self, object):
         return InlineSerializer({}).data  # pragma: no cover
 

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -309,6 +309,7 @@ components:
       required:
       - inline_b
       - inline_i
+      nullable: true
     Query:
       type: object
       properties:


### PR DESCRIPTION
By default, all objects are of type nullable.
 Some validators like `openapi-core` request this parameter from objects and validate it.
 Therefore, support for this parameter should be added.