### PR TITLE
make all readonly fields required for output.

### DIFF
--- a/tests/contrib/test_drf_jwt.yml
+++ b/tests/contrib/test_drf_jwt.yml
@@ -65,6 +65,7 @@ components:
           writeOnly: true
       required:
       - password
+      - token
       - username
     X:
       type: object

--- a/tests/contrib/test_rest_polymorphic.yml
+++ b/tests/contrib/test_rest_polymorphic.yml
@@ -180,8 +180,10 @@ components:
             $ref: '#/components/schemas/Person'
           readOnly: true
       required:
-      - company_name
       - address
+      - board
+      - company_name
+      - id
     NaturalPerson:
       type: object
       properties:
@@ -201,9 +203,10 @@ components:
           type: integer
           nullable: true
       required:
-      - first_name
-      - last_name
       - address
+      - first_name
+      - id
+      - last_name
       - supervisor_id
     PatchedLegalPerson:
       type: object

--- a/tests/contrib/test_simplejwt.yml
+++ b/tests/contrib/test_simplejwt.yml
@@ -86,8 +86,8 @@ components:
           type: string
           writeOnly: true
       required:
-      - username
       - password
+      - username
     TokenRefresh:
       type: object
       properties:

--- a/tests/test_basic.yml
+++ b/tests/test_basic.yml
@@ -211,10 +211,13 @@ components:
         released:
           type: boolean
       required:
-      - title
       - genre
-      - year
+      - id
       - released
+      - single
+      - songs
+      - title
+      - year
     PatchedAlbum:
       type: object
       properties:
@@ -257,8 +260,10 @@ components:
           nullable: true
           readOnly: true
       required:
-      - title
+      - id
       - length
+      - title
+      - top10
     GenreEnum:
       enum:
       - POP

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -288,6 +288,11 @@ components:
           allOf:
           - $ref: '#/components/schemas/FieldLEnum'
           readOnly: true
+      required:
+      - field_i
+      - field_j
+      - field_k
+      - field_l
     Gamma:
       type: object
       properties:

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -177,30 +177,41 @@ components:
             type: string
             format: uuid
       required:
-      - field_decimal_uncoerced
-      - field_regex
-      - field_list
-      - field_int
-      - field_float
+      - field_bigint
       - field_bool
+      - field_bool_override
       - field_char
-      - field_text
-      - field_slug
-      - field_email
-      - field_uuid
-      - field_url
-      - field_ip
-      - field_ip_generic
-      - field_decimal
-      - field_file
-      - field_img
       - field_date
       - field_datetime
-      - field_bigint
-      - field_smallint
+      - field_decimal
+      - field_decimal_uncoerced
+      - field_email
+      - field_file
+      - field_float
       - field_foreign
-      - field_o2o
+      - field_identity_hyperlink
+      - field_img
+      - field_int
+      - field_ip
+      - field_ip_generic
+      - field_list
       - field_m2m
+      - field_method_float
+      - field_method_object
+      - field_model_property_float
+      - field_o2o
+      - field_read_only_nav_uuid
+      - field_read_only_nav_uuid_3steps
+      - field_regex
+      - field_related_hyperlink
+      - field_related_slug
+      - field_related_string
+      - field_slug
+      - field_smallint
+      - field_text
+      - field_url
+      - field_uuid
+      - id
   securitySchemes:
     basicAuth:
       type: http

--- a/tests/test_polymorphic.yml
+++ b/tests/test_polymorphic.yml
@@ -47,6 +47,8 @@ components:
           readOnly: true
       required:
       - company_name
+      - id
+      - type
     MetaPerson:
       oneOf:
       - $ref: '#/components/schemas/LegalPerson'
@@ -73,7 +75,9 @@ components:
           readOnly: true
       required:
       - first_name
+      - id
       - last_name
+      - type
   securitySchemes:
     basicAuth:
       type: http

--- a/tests/test_recursion.yml
+++ b/tests/test_recursion.yml
@@ -48,8 +48,9 @@ components:
           items:
             $ref: '#/components/schemas/TreeNode'
       required:
-      - label
       - children
+      - id
+      - label
   securitySchemes:
     basicAuth:
       type: http


### PR DESCRIPTION
#54 

this should be closer to what DRF is normally doing.
fields are always present in output (though maybe nullable).
does not touch writable files as the field might be indeed optional