### PR TITLE
Workaround to fix 'cannot represent an object'

### DIFF
--- a/drf_spectacular/contrib/djangorestframework_camel_case.py
+++ b/drf_spectacular/contrib/djangorestframework_camel_case.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 
@@ -8,8 +7,6 @@ def camelize_serializer_fields(result, generator, request, public):
     for component in generator.registry._components.values():
         if 'properties' in component.schema:
             component.schema['properties'] = camelize(component.schema['properties'])
-            component.schema['properties'] = json.loads(json.dumps(component.schema['properties']))
-
         if 'required' in component.schema:
             component.schema['required'] = [
                 re.sub(camelize_re, underscore_to_camel, key) for key in component.schema['required']

--- a/drf_spectacular/contrib/djangorestframework_camel_case.py
+++ b/drf_spectacular/contrib/djangorestframework_camel_case.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 
@@ -7,6 +8,8 @@ def camelize_serializer_fields(result, generator, request, public):
     for component in generator.registry._components.values():
         if 'properties' in component.schema:
             component.schema['properties'] = camelize(component.schema['properties'])
+            component.schema['properties'] = json.loads(json.dumps(component.schema['properties']))
+
         if 'required' in component.schema:
             component.schema['required'] = [
                 re.sub(camelize_re, underscore_to_camel, key) for key in component.schema['required']

--- a/drf_spectacular/renderers.py
+++ b/drf_spectacular/renderers.py
@@ -1,6 +1,7 @@
 import yaml
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.renderers import JSONRenderer, BaseRenderer
+from collections import OrderedDict
 
 
 class OpenApiYamlRenderer(BaseRenderer):
@@ -23,6 +24,10 @@ class OpenApiYamlRenderer(BaseRenderer):
             scalar.style = '|' if '\n' in data else None
             return scalar
         Dumper.add_representer(str, multiline_str_representer)
+
+        def map_representer(dumper, data):
+            return dumper.represent_dict(data.items())
+        Dumper.add_representer(OrderedDict, map_representer)
 
         return yaml.dump(
             data,


### PR DESCRIPTION
@tfranzel 

`camelize` returns an `OrderedDict` and schema broke.

```

Request Method: | GET
-- | --
http://127.0.0.1:8000/api/schema/
3.0.7
RepresenterError
('cannot represent an object', OrderedDict([('detail', OrderedDict([('type', 'string')])), ('errorCode', OrderedDict([('type', 'string')]))]))
....python3.8/site-packages/yaml/representer.py in represent_undefined, line 231
```