### PR TITLE
Add `deepLinking` parameter for swagger-ui

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -18,6 +18,7 @@
           SwaggerUIBundle.SwaggerUIStandalonePreset
         ],
         layout: "BaseLayout",
+        deepLinking:true,
         requestInterceptor: (request) => {
           request.headers['X-CSRFToken'] = "{{ csrf_token }}"
           return request;


### PR DESCRIPTION
If set to true, enables deep linking for tags and operations.
https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md

This is a convenient functionality for passing links to schema users