### PR TITLE
Temporarily pin the swagger-ui unpkg URL to 3.30.0

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -4,11 +4,11 @@
     <title>Swagger</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3.30.0/swagger-ui.css" />
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <script src="//unpkg.com/swagger-ui-dist@3.30.0/swagger-ui-bundle.js"></script>
     <script>
     const ui = SwaggerUIBundle({
         url: "{{ schema_url }}",


### PR DESCRIPTION
This should be a temporary fix for #132 until the issue is fixed by swagger-ui [#6249](https://github.com/swagger-api/swagger-ui/issues/6249)