### PR TITLE
Add support for Accept header versioning

### DIFF
--- a/tests/test_versioning_accept_v1.yml
+++ b/tests/test_versioning_accept_v1.yml
@@ -1,0 +1,65 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /x/:
+    get:
+      operationId: x_list
+      description: ''
+      tags:
+      - x
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Xv1'
+          description: ''
+  /x/{id}/:
+    get:
+      operationId: x_retrieve
+      description: ''
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this versioning model.
+        required: true
+      tags:
+      - x
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Xv1'
+          description: ''
+components:
+  schemas:
+    Xv1:
+      type: object
+      properties:
+        id:
+          type: integer
+      required:
+      - id
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: Session

--- a/tests/test_versioning_accept_v2.yml
+++ b/tests/test_versioning_accept_v2.yml
@@ -1,0 +1,66 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /x/:
+    get:
+      operationId: x_list
+      description: ''
+      tags:
+      - x
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Xv2'
+          description: ''
+  /x/{id}/:
+    get:
+      operationId: x_retrieve
+      description: ''
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this versioning model.
+        required: true
+      tags:
+      - x
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Xv2'
+          description: ''
+components:
+  schemas:
+    Xv2:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+      required:
+      - id
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: Session


### PR DESCRIPTION
Hi!

Product that I'm working on uses `Accept` header to determine API version, which is currently not supported by drf_spectacular. This PR tries to amend that.