### PR TITLE
Use sha256 to hash lists

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -567,7 +567,7 @@ def load_enum_name_overrides():
 
 
 def list_hash(lst):
-    return hashlib.blake2b(json.dumps(list(lst), sort_keys=True).encode()).hexdigest()
+    return hashlib.sha256(json.dumps(list(lst), sort_keys=True).encode()).hexdigest()
 
 
 def resolve_regex_path_parameter(path_regex, variable, available_formats):


### PR DESCRIPTION
In our application we support [FIPS 140-2](https://csrc.nist.gov/csrc/media/publications/fips/140/2/final/documents/fips1402annexa.pdf) builds of Python which only include a subset of approved cryptographic algorithms. We use drf-spectacular but blake isn't one of those FIPS approved algorithms. Hoping you'd maybe consider switching to sha256 here.