### PR TITLE
add ref if list field child is serializer

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -465,21 +465,14 @@ class AutoSchema(ViewInspector):
             return append_meta(build_choice_field(field.choices), meta)
 
         if isinstance(field, serializers.ListField):
-            schema = build_array_type({})
-            # TODO check this
-            if not isinstance(field.child, _UnvalidatedField):
-                if is_serializer(field.child):
-                    component = self.resolve_serializer(field.child, direction)
-                    return append_meta(build_array_type(component.ref), meta) if component else None
-                else:
-                    map_field = self._map_serializer_field(field.child, direction)
-                    items = {
-                        "type": map_field.get('type')
-                    }
-                    if 'format' in map_field:
-                        items['format'] = map_field.get('format')
-                    schema['items'] = items
-            return append_meta(schema, meta)
+            if isinstance(field.child, _UnvalidatedField):
+                return append_meta(build_array_type({}), meta)
+            elif is_serializer(field.child):
+                component = self.resolve_serializer(field.child, direction)
+                return append_meta(build_array_type(component.ref), meta) if component else None
+            else:
+                schema = self._map_serializer_field(field.child, direction)
+                return append_meta(build_array_type(schema), meta)
 
         # DateField and DateTimeField type is string
         if isinstance(field, serializers.DateField):

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -468,13 +468,17 @@ class AutoSchema(ViewInspector):
             schema = build_array_type({})
             # TODO check this
             if not isinstance(field.child, _UnvalidatedField):
-                map_field = self._map_serializer_field(field.child, direction)
-                items = {
-                    "type": map_field.get('type')
-                }
-                if 'format' in map_field:
-                    items['format'] = map_field.get('format')
-                schema['items'] = items
+                if is_serializer(field.child):
+                    component = self.resolve_serializer(field.child, direction)
+                    return append_meta(build_array_type(component.ref), meta) if component else None
+                else:
+                    map_field = self._map_serializer_field(field.child, direction)
+                    items = {
+                        "type": map_field.get('type')
+                    }
+                    if 'format' in map_field:
+                        items['format'] = map_field.get('format')
+                    schema['items'] = items
             return append_meta(schema, meta)
 
         # DateField and DateTimeField type is string

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -24,6 +24,13 @@ class Aux(models.Model):
     field_foreign = models.ForeignKey('Aux', null=True, on_delete=models.CASCADE)
 
 
+class AuxSerializer(serializers.ModelSerializer):
+    """ description for aux object """
+    class Meta:
+        fields = '__all__'
+        model = Aux
+
+
 class AllFields(models.Model):
     # basics
     field_int = models.IntegerField()
@@ -61,6 +68,8 @@ class AllFields(models.Model):
     # overrides
     field_regex = models.CharField(max_length=50)
     field_bool_override = models.BooleanField()
+
+    field_serializer = AuxSerializer()
 
     if DJANGO_VERSION >= '3.1':
         field_json = models.JSONField()
@@ -145,16 +154,14 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     # need to set the field explicitly. defined here for both cases to have consistent ordering.
     field_json = serializers.JSONField()
 
+    # list field with serializer
+    field_serializer = serializers.ListField(
+        child=AuxSerializer()
+    )
+
     class Meta:
         fields = '__all__'
         model = AllFields
-
-
-class AuxSerializer(serializers.ModelSerializer):
-    """ description for aux object """
-    class Meta:
-        fields = '__all__'
-        model = Aux
 
 
 class AllFieldsModelViewset(viewsets.ReadOnlyModelViewSet):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -69,8 +69,6 @@ class AllFields(models.Model):
     field_regex = models.CharField(max_length=50)
     field_bool_override = models.BooleanField()
 
-    field_serializer = AuxSerializer()
-
     if DJANGO_VERSION >= '3.1':
         field_json = models.JSONField()
     else:
@@ -85,6 +83,10 @@ class AllFields(models.Model):
     @property
     def field_list(self):
         return [1.1, 2.2, 3.3]
+
+    @property
+    def field_list_object(self):
+        return self.field_m2m.all()
 
     def model_function_basic(self) -> bool:
         return True
@@ -115,6 +117,10 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     # composite fields
     field_list = serializers.ListField(
         child=serializers.FloatField(), min_length=3, max_length=100,
+    )
+    field_list_serializer = serializers.ListField(
+        child=AuxSerializer(),
+        source='field_list_object',
     )
 
     # extra related fields
@@ -153,11 +159,6 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     # there is a JSON model field for django>=3.1 that would be placed automatically. for <=3.1 we
     # need to set the field explicitly. defined here for both cases to have consistent ordering.
     field_json = serializers.JSONField()
-
-    # list field with serializer
-    field_serializer = serializers.ListField(
-        child=AuxSerializer()
-    )
 
     class Meta:
         fields = '__all__'

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -121,6 +121,10 @@ components:
             format: float
           maxItems: 100
           minItems: 3
+        field_list_serializer:
+          type: array
+          items:
+            $ref: '#/components/schemas/Aux'
         field_related_slug:
           type: string
           readOnly: true
@@ -165,10 +169,6 @@ components:
         field_json:
           type: object
           additionalProperties: {}
-        field_serializer:
-          type: array
-          items:
-            $ref: '#/components/schemas/Aux'
         field_int:
           type: integer
         field_float:
@@ -270,6 +270,7 @@ components:
       - field_ip_generic
       - field_json
       - field_list
+      - field_list_serializer
       - field_m2m
       - field_method_float
       - field_method_object
@@ -285,7 +286,6 @@ components:
       - field_related_hyperlink
       - field_related_slug
       - field_related_string
-      - field_serializer
       - field_slug
       - field_smallint
       - field_text

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -165,6 +165,10 @@ components:
         field_json:
           type: object
           additionalProperties: {}
+        field_serializer:
+          type: array
+          items:
+            $ref: '#/components/schemas/Aux'
         field_int:
           type: integer
         field_float:
@@ -281,6 +285,7 @@ components:
       - field_related_hyperlink
       - field_related_slug
       - field_related_string
+      - field_serializer
       - field_slug
       - field_smallint
       - field_text


### PR DESCRIPTION
This change checks if the ListField child is a serializer, and resolves that serializer and creates a ref for that field. Please let me know if there is a better or more elegant way for me to approach this issue.

### Scenario
This was something that came up when migrating from [drf-yasg](https://github.com/axnsan12/drf-yasg).  There was a Serializer ("User") that referenced a ListField with the child property pointed towards another serializer ("ProfileFields"):

```
    profile = serializers.ListField(
        source="cached_profilefields",
        read_only=True,
        child=ProfileFieldsSerializer(),
    )
```

The specification with drf-yasg would be generated as:
```
      profile:
        type: array
        items:
          "$ref": "#/definitions/UserProfileFields"
        readOnly: true
```

However, with `drf-spectacular`, the specification was generating as:
```
profile:
          type: array
          items:
            type: null
          readOnly: true
```

With this change, drf-spectacular will now generate that property as:

```
        profile:
          type: array
          items:
            $ref: '#/components/schemas/PatientRecordField'
          readOnly: true
```