### PR TITLE
add enum postprocessing handling of blank and null #135

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -222,8 +222,7 @@ class AutoSchema(ViewInspector):
                 object=authenticator.__class__,
                 schema=scheme.get_security_definition(self)
             )
-            if component not in self.registry:
-                self.registry.register(component)
+            self.registry.register_on_missing(component)
 
         perms = [p.__class__ for p in self.view.get_permissions()]
         if permissions.AllowAny in perms:
@@ -459,10 +458,10 @@ class AutoSchema(ViewInspector):
             return append_meta(build_basic_type(OpenApiTypes.URI), meta)
 
         if isinstance(field, serializers.MultipleChoiceField):
-            return append_meta(build_array_type(build_choice_field(field.choices)), meta)
+            return append_meta(build_array_type(build_choice_field(field)), meta)
 
         if isinstance(field, serializers.ChoiceField):
-            return append_meta(build_choice_field(field.choices), meta)
+            return append_meta(build_choice_field(field), meta)
 
         if isinstance(field, serializers.ListField):
             if isinstance(field.child, _UnvalidatedField):

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -267,8 +267,9 @@ def build_parameter_type(
     return schema
 
 
-def build_choice_field(choices):
-    choices = list(OrderedDict.fromkeys(choices))  # preserve order and remove duplicates
+def build_choice_field(field):
+    choices = list(OrderedDict.fromkeys(field.choices))  # preserve order and remove duplicates
+
     if all(isinstance(choice, bool) for choice in choices):
         type = 'boolean'
     elif all(isinstance(choice, int) for choice in choices):
@@ -280,6 +281,11 @@ def build_choice_field(choices):
         type = 'string'
     else:
         type = None
+
+    if field.allow_blank:
+        choices.append('')
+    if field.allow_null:
+        choices.append(None)
 
     schema = {
         # The value of `enum` keyword MUST be an array and SHOULD be unique.
@@ -457,6 +463,10 @@ class ComponentRegistry:
                 f'a incorrect schema. Look out for reused names'
             )
         self._components[component.key] = component
+
+    def register_on_missing(self, component: ResolvedComponent):
+        if component.key not in self._components:
+            self._components[component.key] = component
 
     def __contains__(self, component):
         if component.key not in self._components:

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -20,7 +20,7 @@ class ASerializer(serializers.Serializer):
 
 
 class BSerializer(serializers.Serializer):
-    language = serializers.ChoiceField(choices=language_choices)
+    language = serializers.ChoiceField(choices=language_choices, allow_blank=True, allow_null=True)
 
 
 class AViewset(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/tests/test_postprocessing.yml
+++ b/tests/test_postprocessing.yml
@@ -52,9 +52,16 @@ components:
       type: object
       properties:
         language:
-          $ref: '#/components/schemas/LanguageEnum'
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/LanguageEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
       required:
       - language
+    BlankEnum:
+      enum:
+      - ''
     LanguageEnum:
       enum:
       - en
@@ -62,6 +69,9 @@ components:
       - ru
       - cn
       type: string
+    NullEnum:
+      enum:
+      - null
   securitySchemes:
     basicAuth:
       type: http


### PR DESCRIPTION
proposal for #135 

introduced `blankEnum` and `nullEnum` that get `oneOf`ed in the property where appropriate. this solution keeps the original enum constant and the `null` and `''` get dynamically mixed in. which means there is **one** enum for all variations.

`openapi-generator` produces useable output. the `typescript-angular` target is not 100% correct but fully functional. `swagger-ui` rendering is a bit lacking but this is also the case for a plain enum with `null` and `''`. the schema is valid and as specified in https://swagger.io/docs/specification/data-models/enums/

@jayvdb could you check if this works for you?