### PR TITLE
fix for AcceptVersioningHeader support

### DIFF
--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -146,8 +146,10 @@ class SchemaGenerator(BaseSchemaGenerator):
                     or getattr(request, 'version', None)  # incoming request was versioned
                     or view.versioning_class.default_version  # fallback
                 )
+                if not version:
+                    continue
                 path = modify_for_versioning(self.inspector.patterns, method, path, view, version)
-                if not version or not operation_matches_version(view, version):
+                if not operation_matches_version(view, version):
                     continue
 
             assert isinstance(view.schema, AutoSchema), (

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,9 @@ python_version = 3.6
 [mypy-rest_framework.compat.*]
 ignore_missing_imports = True
 
+[mypy-rest_framework.utils.mediatypes.*]
+ignore_missing_imports = True
+
 [mypy-rest_framework_simplejwt.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Prevent the content negotiation to use the wrong renderer,
when a real request is passed.

https://github.com/tfranzel/drf-spectacular/commit/e3103edfa08d071a349c6861b9d0d3c854636309#r42855875