### PR TITLE
Allow Swagger-UI configuration through settings Closes #162 and Closes #160

### DIFF
--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -28,6 +28,10 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SERVE_INCLUDE_SCHEMA': True,
     'SERVE_PERMISSIONS': ['rest_framework.permissions.AllowAny'],
 
+    # Dictionary of configurations to pass to the SwaggerUI({ ... })
+    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+    'SWAGGER_UI_SETTINGS': {},
+
     # Append OpenAPI objects to path and components in addition to the generated objects
     'APPEND_PATHS': {},
     'APPEND_COMPONENTS': {},
@@ -84,10 +88,6 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'OAUTH2_TOKEN_URL': None,
     'OAUTH2_REFRESH_URL': None,
     'OAUTH2_SCOPES': None,
-
-    # Dictionary of configurations to pass to the SwaggerUI({ ... })
-    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
-    'SWAGGER_SETTINGS': {}
 }
 
 IMPORT_STRINGS = [

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -84,6 +84,10 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'OAUTH2_TOKEN_URL': None,
     'OAUTH2_REFRESH_URL': None,
     'OAUTH2_SCOPES': None,
+    
+    # Dictionary of configurations to pass to the SwaggerUI({ ... }) 
+    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+    'SWAGGER_SETTINGS': {}
 }
 
 IMPORT_STRINGS = [

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -84,8 +84,8 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'OAUTH2_TOKEN_URL': None,
     'OAUTH2_REFRESH_URL': None,
     'OAUTH2_SCOPES': None,
-    
-    # Dictionary of configurations to pass to the SwaggerUI({ ... }) 
+
+    # Dictionary of configurations to pass to the SwaggerUI({ ... })
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
     'SWAGGER_SETTINGS': {}
 }

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -10,7 +10,9 @@
     <div id="swagger-ui"></div>
     <script src="//unpkg.com/swagger-ui-dist@3.35.0/swagger-ui-bundle.js"></script>
     <script>
+    var swagger_settings  = {{ settings|safe }}
     const ui = SwaggerUIBundle({
+        ...swagger_settings,
         url: "{{ schema_url }}",
         dom_id: '#swagger-ui',
         presets: [

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -12,7 +12,6 @@
     <script>
     var swagger_settings  = {{ settings|safe }}
     const ui = SwaggerUIBundle({
-        ...swagger_settings,
         url: "{{ schema_url }}",
         dom_id: '#swagger-ui',
         presets: [
@@ -24,7 +23,8 @@
         requestInterceptor: (request) => {
           request.headers['X-CSRFToken'] = "{{ csrf_token }}"
           return request;
-        }
+        },
+        ...swagger_settings
       })
     </script>
   </body>

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -1,3 +1,5 @@
+import json
+
 from collections import namedtuple
 from typing import Any, Dict
 
@@ -83,8 +85,9 @@ class SpectacularSwaggerView(APIView):
         schema_url = self.url or reverse(self.url_name, request=request)
         if request.GET.get('lang'):
             schema_url += f'{"&" if "?" in schema_url else "?"}lang={request.GET.get("lang")}'
+        settings = json.dumps(spectacular_settings.SWAGGER_SETTINGS)
         return Response(
-            {'schema_url': schema_url},
+            {'schema_url': schema_url, 'settings': settings},
             template_name=self.template_name
         )
 

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -1,5 +1,4 @@
 import json
-
 from collections import namedtuple
 from typing import Any, Dict
 
@@ -85,7 +84,7 @@ class SpectacularSwaggerView(APIView):
         schema_url = self.url or reverse(self.url_name, request=request)
         if request.GET.get('lang'):
             schema_url += f'{"&" if "?" in schema_url else "?"}lang={request.GET.get("lang")}'
-        settings = json.dumps(spectacular_settings.SWAGGER_SETTINGS)
+        settings = json.dumps(spectacular_settings.SWAGGER_UI_SETTINGS)
         return Response(
             {'schema_url': schema_url, 'settings': settings},
             template_name=self.template_name


### PR DESCRIPTION
Adds a SWAGGER_UI_SETTINGS dictionary that allows configurations to be passed to the SwaggerUIBundle({})