### PR TITLE
Support swagger ui configuration with spectacular settings #160

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -36,7 +36,7 @@ The following are known to be effective:
 - ``SCHEMA_COERCE_PATH_PK``
 
 
-Example: API Key securitySchemes & security setting
+Example: API Key securitySchemes & security setting & SwaggerUI Config
 ---------------------------------------------------------------------
 
 When using djangorestframework-api-key_ for example, the `specs
@@ -60,4 +60,24 @@ This can be done in the following way:
             }
         },
         "SECURITY": [{"ApiKeyAuth": [], }],
+
+        # check SwaggerUI Version what you want, https://github.com/swagger-api/swagger-ui/releases
+        "SWAGGER_UI_DIST": '//unpkg.com/swagger-ui-dist@3.35.1', # default
+        "FAVICON_HREF": settings.STATIC_URL + "your_company_favicon.png", # default is swagger favicon
+
+        # configuration param should correspond to the documents below.
+        # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+        'SWAGGER_UI_CONFIG': {
+            'dom_id': '#swagger-ui', # requried(default)
+            'layout': "BaseLayout",  # requried(default)
+            'deepLinking': True,
+            'persistAuthorization': True,
+            'displayOperationId': True,
+            # ...
+        },
     }
+..
+
+We does not support SwaggerUI Config Param at the settings.py which is based JS Function
+
+If you want, override swagger_ui.html & SpectacularSwaggerView.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -36,8 +36,8 @@ The following are known to be effective:
 - ``SCHEMA_COERCE_PATH_PK``
 
 
-Example: API Key securitySchemes & security setting & SwaggerUI Config
----------------------------------------------------------------------
+Example: API Key securitySchemes & security setting
+----------------------------------------------------
 
 When using djangorestframework-api-key_ for example, the `specs
 <https://swagger.io/docs/specification/authentication/>`_  tell you you need to add an entry to the securitySchemes component and set it to the global security section.
@@ -60,24 +60,36 @@ This can be done in the following way:
             }
         },
         "SECURITY": [{"ApiKeyAuth": [], }],
-
-        # check SwaggerUI Version what you want, https://github.com/swagger-api/swagger-ui/releases
-        "SWAGGER_UI_DIST": '//unpkg.com/swagger-ui-dist@3.35.1', # default
-        "FAVICON_HREF": settings.STATIC_URL + "your_company_favicon.png", # default is swagger favicon
-
-        # configuration param should correspond to the documents below.
-        # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
-        'SWAGGER_UI_CONFIG': {
-            'dom_id': '#swagger-ui', # requried(default)
-            'layout': "BaseLayout",  # requried(default)
-            'deepLinking': True,
-            'persistAuthorization': True,
-            'displayOperationId': True,
-            # ...
-        },
+         ...
     }
-..
+
+
+
+Example: SwaggerUI settings
+----------------------------
 
 We does not support SwaggerUI Config Param at the settings.py which is based JS Function
 
 If you want, override swagger_ui.html & SpectacularSwaggerView.
+
+.. code:: python
+
+    SPECTACULAR_SETTINGS = {
+        ...
+        # configuration param should correspond to the documents below.
+        # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+        "SWAGGER_UI_SETTINGS": {
+            "dom_id": "#swagger-ui", # default
+            "layout": "BaseLayout",  # requried(default)
+            "deepLinking": True,
+            "persistAuthorization": True,
+            "displayOperationId": True,
+            # ...
+        },
+
+        # check SwaggerUI Version what you want, https://github.com/swagger-api/swagger-ui/releases
+        "SWAGGER_UI_DIST": "//unpkg.com/swagger-ui-dist@3.35.1", # default
+        "FAVICON_HREF": settings.STATIC_URL + "your_company_favicon.png", # default is swagger favicon
+        ...
+    }
+

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -9,6 +9,16 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SCHEMA_PATH_PREFIX': r'',
     'DEFAULT_GENERATOR_CLASS': 'drf_spectacular.generators.SchemaGenerator',
 
+    'SWAGGER_UI_DIST': '//unpkg.com/swagger-ui-dist@3.35.1',
+    'FAVICON_HREF': '//unpkg.com/swagger-ui-dist@3.35.1/favicon-32x32.png',
+    # configuration param should correspond to the documents below.
+    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+    'SWAGGER_UI_SETTINGS': {
+        'dom_id': '#swagger-ui',
+        'layout': "BaseLayout",
+        'deepLinking': True,
+    },
+
     # Schema generation parameters to influence how components are constructed.
     # Some schema features might not translate well to your target.
     # Demultiplexing/modifying components might help alleviate those issues.
@@ -30,7 +40,6 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
 
     # Dictionary of configurations to pass to the SwaggerUI({ ... })
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
-    'SWAGGER_UI_SETTINGS': {},
 
     # Append OpenAPI objects to path and components in addition to the generated objects
     'APPEND_PATHS': {},

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -11,7 +11,7 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
 
     'SWAGGER_UI_DIST': '//unpkg.com/swagger-ui-dist@3.35.1',
     'FAVICON_HREF': '//unpkg.com/swagger-ui-dist@3.35.1/favicon-32x32.png',
-    # configuration param should correspond to the documents below.
+    # Dictionary of configurations to pass to the SwaggerUI({ ... })
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
     'SWAGGER_UI_SETTINGS': {
         'dom_id': '#swagger-ui',

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -9,15 +9,14 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SCHEMA_PATH_PREFIX': r'',
     'DEFAULT_GENERATOR_CLASS': 'drf_spectacular.generators.SchemaGenerator',
 
-    'SWAGGER_UI_DIST': '//unpkg.com/swagger-ui-dist@3.35.1',
-    'FAVICON_HREF': '//unpkg.com/swagger-ui-dist@3.35.1/favicon-32x32.png',
     # Dictionary of configurations to pass to the SwaggerUI({ ... })
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
     'SWAGGER_UI_SETTINGS': {
-        'dom_id': '#swagger-ui',
         'layout': "BaseLayout",
         'deepLinking': True,
     },
+    'SWAGGER_UI_DIST': '//unpkg.com/swagger-ui-dist@3.35.1',
+    'SWAGGER_UI_FAVICON_HREF': '//unpkg.com/swagger-ui-dist@3.35.1/favicon-32x32.png',
 
     # Schema generation parameters to influence how components are constructed.
     # Some schema features might not translate well to your target.

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -38,9 +38,6 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SERVE_INCLUDE_SCHEMA': True,
     'SERVE_PERMISSIONS': ['rest_framework.permissions.AllowAny'],
 
-    # Dictionary of configurations to pass to the SwaggerUI({ ... })
-    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
-
     # Append OpenAPI objects to path and components in addition to the generated objects
     'APPEND_PATHS': {},
     'APPEND_COMPONENTS': {},

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -4,26 +4,33 @@
     <title>Swagger</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/png" href="{{swagger_bundle_favicon_href}}"/>
-    <link rel="stylesheet" type="text/css" href="{{swagger_bundle_css_href}}" />
+    {% if favicon_href %}
+    <link rel="icon" type="image/png" href="{{favicon_href}}"/>
+    {% endif %}
+    <link rel="stylesheet" type="text/css" href="{{dist}}/swagger-ui.css" />
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="{{swagger_bundle_js_href}}"></script>
+    <script src="{{dist}}/swagger-ui-bundle.js"></script>
     <script>
-    const swagger_settings  = {{ swagger_ui_settings|safe }}
+    const swagger_settings  = {{ settings|safe }}
+
     const ui = SwaggerUIBundle({
+      url: "{{ schema_url }}",
+      dom_id: '#swagger-ui',
       presets: [
         SwaggerUIBundle.presets.apis,
       ],
       plugin: [
         SwaggerUIBundle.plugins.DownloadUrl
       ],
+      layout: "BaseLayout",
       requestInterceptor: (request) => {
         request.headers['X-CSRFToken'] = "{{ csrf_token }}"
         return request;
       },
-      ...swagger_settings
+      ...swagger_settings,
+
     })
     </script>
   </body>

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -4,28 +4,27 @@
     <title>Swagger</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3.35.0/swagger-ui.css" />
+    <link rel="icon" type="image/png" href="{{swagger_bundle_favicon_href}}"/>
+    <link rel="stylesheet" type="text/css" href="{{swagger_bundle_css_href}}" />
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="//unpkg.com/swagger-ui-dist@3.35.0/swagger-ui-bundle.js"></script>
+    <script src="{{swagger_bundle_js_href}}"></script>
     <script>
-    var swagger_settings  = {{ settings|safe }}
+    const swagger_settings  = {{ swagger_ui_settings|safe }}
     const ui = SwaggerUIBundle({
-        url: "{{ schema_url }}",
-        dom_id: '#swagger-ui',
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIBundle.SwaggerUIStandalonePreset
-        ],
-        layout: "BaseLayout",
-        deepLinking:true,
-        requestInterceptor: (request) => {
-          request.headers['X-CSRFToken'] = "{{ csrf_token }}"
-          return request;
-        },
-        ...swagger_settings
-      })
+      presets: [
+        SwaggerUIBundle.presets.apis,
+      ],
+      plugin: [
+        SwaggerUIBundle.plugins.DownloadUrl
+      ],
+      requestInterceptor: (request) => {
+        request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+        return request;
+      },
+      ...swagger_settings
+    })
     </script>
   </body>
 </html>

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 
 from django.conf import settings
 from django.utils import translation
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
@@ -82,22 +81,17 @@ class SpectacularSwaggerView(APIView):
 
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
-        swagger_bundle_js_href = "{}/swagger-ui-bundle.js".format(spectacular_settings.SWAGGER_UI_DIST)
-        swagger_bundle_css_href = "{}/swagger-ui.css".format(spectacular_settings.SWAGGER_UI_DIST)
-        swagger_bundle_favicon_href = "{}".format(spectacular_settings.FAVICON_HREF)
 
         schema_url = self.url or reverse(self.url_name, request=request)
-        swagger_ui_settings = {'url': schema_url}
-        swagger_ui_settings.update(spectacular_settings.SWAGGER_UI_SETTINGS)
-
         if request.GET.get('lang'):
             schema_url += f'{"&" if "?" in schema_url else "?"}lang={request.GET.get("lang")}'
+
         return Response(
             {
-                'swagger_ui_settings': mark_safe(json.dumps(swagger_ui_settings)),
-                'swagger_bundle_js_href': swagger_bundle_js_href,
-                'swagger_bundle_css_href': swagger_bundle_css_href,
-                'swagger_bundle_favicon_href': swagger_bundle_favicon_href,
+                'schema_url': schema_url,
+                'settings': json.dumps(spectacular_settings.SWAGGER_UI_SETTINGS),
+                'dist': spectacular_settings.SWAGGER_UI_DIST,
+                'favicon_href': spectacular_settings.SWAGGER_UI_FAVICON_HREF,
             },
             template_name=self.template_name
         )

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from django.conf import settings
 from django.utils import translation
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
@@ -81,12 +82,23 @@ class SpectacularSwaggerView(APIView):
 
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
+        swagger_bundle_js_href = "{}/swagger-ui-bundle.js".format(spectacular_settings.SWAGGER_UI_DIST)
+        swagger_bundle_css_href = "{}/swagger-ui.css".format(spectacular_settings.SWAGGER_UI_DIST)
+        swagger_bundle_favicon_href = "{}".format(spectacular_settings.FAVICON_HREF)
+
         schema_url = self.url or reverse(self.url_name, request=request)
+        swagger_ui_settings = {'url': schema_url}
+        swagger_ui_settings.update(spectacular_settings.SWAGGER_UI_SETTINGS)
+
         if request.GET.get('lang'):
             schema_url += f'{"&" if "?" in schema_url else "?"}lang={request.GET.get("lang")}'
-        settings = json.dumps(spectacular_settings.SWAGGER_UI_SETTINGS)
         return Response(
-            {'schema_url': schema_url, 'settings': settings},
+            {
+                'swagger_ui_settings': mark_safe(json.dumps(swagger_ui_settings)),
+                'swagger_bundle_js_href': swagger_bundle_js_href,
+                'swagger_bundle_css_href': swagger_bundle_css_href,
+                'swagger_bundle_favicon_href': swagger_bundle_favicon_href,
+            },
             template_name=self.template_name
         )
 


### PR DESCRIPTION
proposal for #160 

Support SwaggerUI Config not only `persistAuthorization` but alse All (but  excluding JS Function based Config)


### Expected

#### support SwaggerUI Config to settings.py

~~~Python 

SPECTACULAR_SETTINGS = {
       ...

        # I think we don't have to release anymore just trying to version up Swagger-ui-dist
        "SWAGGER_UI_DIST": '//unpkg.com/swagger-ui-dist@3.35.1', # default

        # configuration param should correspond to the documents below.
        # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
        'SWAGGER_UI_SETTINGS': {
            'dom_id': '#swagger-ui', # requried(default)
            'layout': "BaseLayout",  # requried(default)
            'deepLinking': True,
            'persistAuthorization': True,
            'displayOperationId': True,
            # ...
        },
    }

~~~

#### nitpick fix
 fix Issue, swagger favicon does not exist 


### P.S.

I add plugin ` SwaggerUIBundle.plugins.DownloadUrl` to `drf-spectacular  swagger-ui.html`
i would like to ask if this option is a problem.
