### PR TITLE
instance check with ViewSetMixin instead of GenericViewSet #166

### DIFF
--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -83,7 +83,7 @@ class SchemaGenerator(BaseSchemaGenerator):
 
         view = super().create_view(callback, method, request)
 
-        if isinstance(view, viewsets.GenericViewSet) or isinstance(view, viewsets.ViewSet):
+        if isinstance(view, viewsets.ViewSetMixin):
             action = getattr(view, view.action)
         elif isinstance(view, views.APIView):
             action = getattr(view, method.lower())


### PR DESCRIPTION
resolve #166 

~~~Python

# rest_framework views.py

class ViewSet(ViewSetMixin, views.APIView):
    """
    The base ViewSet class does not provide any actions by default.
    """
    pass


class GenericViewSet(ViewSetMixin, generics.GenericAPIView):
   .....


~~~~


@ngocngoan

we can resolve this issue easliy. 

but it does not mean `drf-spectacular` officially support `django-rest-framework-mongoengine` 



I 'm not a maintainer 
therefore My Comment does not valid 

Maintainer : @tfranzel 

I think `check instance ViewSetMixin instead of ViewSet & GenericViewSet ` is more expandable

can I ask your Opinion , Is it appropriate? 
