### PR TITLE
Update README.rst with missing imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ from your API. We also provide convenience wrappers for `swagger-ui` or `redoc`.
 
 .. code:: python
 
-    from drf_spectacular.views import SpectacularAPIView
+    from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
     urlpatterns = [
         # YOUR PATTERNS
         path('api/schema/', SpectacularAPIView.as_view(), name='schema'),


### PR DESCRIPTION
**Describe the bug**
Missing some imports on python's exemple at `Take it for a spin` section

**To Reproduce**
REAMDE.rst file shows 
```python
from drf_spectacular.views import SpectacularAPIView
```

**Expected behavior**
REAMDE.rst file should shows 
```python
from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
```
