### PR TITLE
Add password format

### DIFF
--- a/drf_spectacular/types.py
+++ b/drf_spectacular/types.py
@@ -19,6 +19,7 @@ class OpenApiTypes(enum.Enum):
     STR = enum.auto()
     BYTE = enum.auto()  # base64 encoded
     BINARY = enum.auto()
+    PASSWORD = enum.auto()
     INT = enum.auto()
     UUID = enum.auto()
     URI = enum.auto()
@@ -40,7 +41,8 @@ OPENAPI_TYPE_MAPPING = {
     OpenApiTypes.BOOL: {'type': 'boolean'},
     OpenApiTypes.STR: {'type': 'string'},
     OpenApiTypes.BYTE: {'type': 'string', 'format': 'byte'},
-    OpenApiTypes.BINARY: {'type': 'string', 'format': 'binary'},
+    OpenApiTypes.BINARY: {'type': 'string', 'format': 'binary'}.
+    OpenApiTypes.PASSWORD: {'type': 'string', 'format': 'password'},
     OpenApiTypes.INT: {'type': 'integer'},
     OpenApiTypes.UUID: {'type': 'string', 'format': 'uuid'},
     OpenApiTypes.URI: {'type': 'string', 'format': 'uri'},

--- a/drf_spectacular/types.py
+++ b/drf_spectacular/types.py
@@ -41,7 +41,7 @@ OPENAPI_TYPE_MAPPING = {
     OpenApiTypes.BOOL: {'type': 'boolean'},
     OpenApiTypes.STR: {'type': 'string'},
     OpenApiTypes.BYTE: {'type': 'string', 'format': 'byte'},
-    OpenApiTypes.BINARY: {'type': 'string', 'format': 'binary'}.
+    OpenApiTypes.BINARY: {'type': 'string', 'format': 'binary'},
     OpenApiTypes.PASSWORD: {'type': 'string', 'format': 'password'},
     OpenApiTypes.INT: {'type': 'integer'},
     OpenApiTypes.UUID: {'type': 'string', 'format': 'uuid'},


### PR DESCRIPTION
As mentioned in the [OAS3 DataTypes page](https://swagger.io/docs/specification/data-models/data-types/ ), the `format='password'`  option tells the UI to encode the field. I think then it would be nice to add it, specially for endpoints like the simple_jwt authentication one.


> An optional format modifier serves as a hint at the contents and format of the string. OpenAPI defines the following built-in string formats:
date – full-date notation as defined by RFC 3339, section 5.6, for example, 2017-07-21
date-time – the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z
password – a hint to UIs to mask the input
byte – base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==
binary – binary data, used to describe files (see Files below)