### PR TITLE
Fix security definition for IsAuthenticatedOrReadOnly permission

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -231,7 +231,7 @@ class AutoSchema(ViewInspector):
         perms = [p.__class__ for p in self.view.get_permissions()]
         if permissions.AllowAny in perms:
             auths.append({})
-        elif permissions.IsAuthenticatedOrReadOnly in perms and self.method not in ('PUT', 'PATCH', 'POST'):
+        elif permissions.IsAuthenticatedOrReadOnly in perms and self.method in permissions.SAFE_METHODS:
             auths.append({})
         return auths
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,7 +5,7 @@ from django.db import models
 from rest_framework import serializers, viewsets
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
 from tests import assert_schema, generate_schema
@@ -61,7 +61,7 @@ class AlbumModelViewset(viewsets.ModelViewSet):
     serializer_class = AlbumSerializer
     queryset = Album.objects.none()
 
-    @action(detail=True, methods=['POST'], serializer_class=LikeSerializer, permission_classes=[IsAuthenticated])
+    @action(detail=True, methods=['POST'], serializer_class=LikeSerializer)
     def like(self, request):
         return Response(self.get_serializer().data)  # pragma: no cover
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,6 +5,7 @@ from django.db import models
 from rest_framework import serializers, viewsets
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
 from tests import assert_schema, generate_schema
@@ -56,10 +57,11 @@ class LikeSerializer(serializers.Serializer):
 
 class AlbumModelViewset(viewsets.ModelViewSet):
     authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = AlbumSerializer
     queryset = Album.objects.none()
 
-    @action(detail=True, methods=['POST'], serializer_class=LikeSerializer)
+    @action(detail=True, methods=['POST'], serializer_class=LikeSerializer, permission_classes=[IsAuthenticated])
     def like(self, request):
         return Response(self.get_serializer().data)  # pragma: no cover
 

--- a/tests/test_basic.yml
+++ b/tests/test_basic.yml
@@ -43,7 +43,6 @@ paths:
         required: true
       security:
       - tokenAuth: []
-      - {}
       responses:
         '200':
           content:
@@ -102,7 +101,6 @@ paths:
         required: true
       security:
       - tokenAuth: []
-      - {}
       responses:
         '200':
           content:
@@ -136,7 +134,6 @@ paths:
               $ref: '#/components/schemas/PatchedAlbum'
       security:
       - tokenAuth: []
-      - {}
       responses:
         '200':
           content:
@@ -159,7 +156,6 @@ paths:
       - albums
       security:
       - tokenAuth: []
-      - {}
       responses:
         '204':
           description: No response body
@@ -179,7 +175,6 @@ paths:
       - albums
       security:
       - tokenAuth: []
-      - {}
       responses:
         '200':
           description: No response body


### PR DESCRIPTION
## Problem

When `IsAuthenticatedOrReadOnly` permission is set on a view, incorrect security definitions are generated.

`IsAuthenticatedOrReadOnly` disallows all request methods other than `GET`, `HEAD` and `OPTIONS` if user is not authenticated. This means `DELETE` method is disallowed too.

The current implementation only checks if the method is `PUT`, `PATCH`, `POST` and adds `{}` security for `DELETE` too.

## Solution

Use `permissions.SAFE_METHODS` to determine if non-auth ({}) security permission should be added to a path