### PR TITLE
Support title keyword

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -28,7 +28,6 @@ class SpectacularDjangoFilterBackendMixin:
                 required=field.extra['required'],
                 location=OpenApiParameter.QUERY,
                 description=field.label if field.label is not None else field_name,
-                title=field.label if field.label is not None else field_name,
                 schema=view.schema._map_model_field(model_field, direction=None),
                 enum=[c for c, _ in field.extra.get('choices', [])],
             ))

--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -28,6 +28,7 @@ class SpectacularDjangoFilterBackendMixin:
                 required=field.extra['required'],
                 location=OpenApiParameter.QUERY,
                 description=field.label if field.label is not None else field_name,
+                title=field.label if field.label is not None else field_name,
                 schema=view.schema._map_model_field(model_field, direction=None),
                 enum=[c for c, _ in field.extra.get('choices', [])],
             ))

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -649,6 +649,8 @@ class AutoSchema(ViewInspector):
             meta['default'] = default
         if field.help_text:
             meta['description'] = str(field.help_text)
+        if field.label:
+            meta['title'] = str(field.label)
         return meta
 
     def _map_basic_serializer(self, serializer, direction):

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -189,6 +189,7 @@ def build_parameter_type(
         location,
         required=False,
         description=None,
+        title=None,
         enum=None,
         deprecated=False,
         explode=None,
@@ -202,6 +203,8 @@ def build_parameter_type(
     }
     if description:
         schema['description'] = description
+    if title:
+        schema['title'] = title
     if required or location == 'path':
         schema['required'] = True
     if deprecated:

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -68,12 +68,14 @@ class OpenApiParameter(OpenApiSchemaBase):
     HEADER = 'header'
     COOKIE = 'cookie'
 
-    def __init__(self, name, type=str, location=QUERY, required=False, description='', enum=None, deprecated=False):
+    def __init__(self, name, type=str, location=QUERY, required=False,
+                 description='', title='', enum=None, deprecated=False):
         self.name = name
         self.type = type
         self.location = location
         self.required = required
         self.description = description
+        self.title = title
         self.enum = enum
         self.deprecated = deprecated
 

--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -43,6 +43,7 @@ paths:
         name: sub
         schema:
           type: integer
+          title: ID
         description: sub
       - in: query
         name: subproduct__sub_price
@@ -74,6 +75,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this product.
         required: true
       tags:
@@ -102,15 +104,21 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         category:
-          $ref: '#/components/schemas/CategoryEnum'
+          allOf:
+          - $ref: '#/components/schemas/CategoryEnum'
+          title: Category
         in_stock:
           type: boolean
+          title: In stock
         price:
           type: number
           format: float
+          title: Price
         other_sub_product:
           type: integer
+          title: Other sub product
       required:
       - category
       - id

--- a/tests/contrib/test_djangorestframework_camel_case.yml
+++ b/tests/contrib/test_djangorestframework_camel_case.yml
@@ -46,8 +46,10 @@ components:
       properties:
         fieldOne:
           type: string
+          title: Field one
         fieldTwo:
           type: string
+          title: Field two
       required:
       - fieldOne
       - fieldTwo

--- a/tests/contrib/test_drf_jwt.yml
+++ b/tests/contrib/test_drf_jwt.yml
@@ -63,12 +63,15 @@ components:
         password:
           type: string
           writeOnly: true
+          title: Password
         token:
           type: string
           readOnly: true
+          title: Token
         username:
           type: string
           writeOnly: true
+          title: Username
       required:
       - password
       - token
@@ -79,6 +82,7 @@ components:
         uuid:
           type: string
           format: uuid
+          title: Uuid
       required:
       - uuid
   securitySchemes:

--- a/tests/contrib/test_oauth_toolkit.yml
+++ b/tests/contrib/test_oauth_toolkit.yml
@@ -66,6 +66,7 @@ components:
         uuid:
           type: string
           format: uuid
+          title: Uuid
       required:
       - uuid
   securitySchemes:

--- a/tests/contrib/test_rest_auth.yml
+++ b/tests/contrib/test_rest_auth.yml
@@ -318,11 +318,14 @@ components:
       properties:
         username:
           type: string
+          title: Username
         email:
           type: string
           format: email
+          title: Email
         password:
           type: string
+          title: Password
       required:
       - password
     PasswordChange:
@@ -330,9 +333,11 @@ components:
       properties:
         new_password1:
           type: string
+          title: New password1
           maxLength: 128
         new_password2:
           type: string
+          title: New password2
           maxLength: 128
       required:
       - new_password1
@@ -344,6 +349,7 @@ components:
         email:
           type: string
           format: email
+          title: Email
       required:
       - email
     PasswordResetConfirm:
@@ -352,14 +358,18 @@ components:
       properties:
         new_password1:
           type: string
+          title: New password1
           maxLength: 128
         new_password2:
           type: string
+          title: New password2
           maxLength: 128
         uid:
           type: string
+          title: Uid
         token:
           type: string
+          title: Token
       required:
       - new_password1
       - new_password2
@@ -372,38 +382,47 @@ components:
         pk:
           type: integer
           readOnly: true
+          title: ID
         username:
           type: string
           description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
+          title: Username
           pattern: ^[\w.@+-]+$
           maxLength: 150
         email:
           type: string
           format: email
           readOnly: true
+          title: Email address
         first_name:
           type: string
+          title: First name
           maxLength: 150
         last_name:
           type: string
+          title: Last name
           maxLength: 150
     Register:
       type: object
       properties:
         username:
           type: string
+          title: Username
           maxLength: 150
           minLength: 1
         email:
           type: string
           format: email
+          title: Email
         password1:
           type: string
           writeOnly: true
+          title: Password1
         password2:
           type: string
           writeOnly: true
+          title: Password2
       required:
       - password1
       - password2
@@ -414,6 +433,7 @@ components:
         detail:
           type: string
           readOnly: true
+          title: Detail
       required:
       - detail
     Token:
@@ -422,6 +442,7 @@ components:
       properties:
         key:
           type: string
+          title: Key
           maxLength: 40
       required:
       - key
@@ -432,21 +453,26 @@ components:
         pk:
           type: integer
           readOnly: true
+          title: ID
         username:
           type: string
           description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
+          title: Username
           pattern: ^[\w.@+-]+$
           maxLength: 150
         email:
           type: string
           format: email
           readOnly: true
+          title: Email address
         first_name:
           type: string
+          title: First name
           maxLength: 150
         last_name:
           type: string
+          title: Last name
           maxLength: 150
       required:
       - email
@@ -457,6 +483,7 @@ components:
       properties:
         key:
           type: string
+          title: Key
       required:
       - key
   securitySchemes:

--- a/tests/contrib/test_rest_auth_token.yml
+++ b/tests/contrib/test_rest_auth_token.yml
@@ -373,10 +373,14 @@ components:
       properties:
         access_token:
           type: string
+          title: Access token
         refresh_token:
           type: string
+          title: Refresh token
         user:
-          $ref: '#/components/schemas/UserDetails'
+          allOf:
+          - $ref: '#/components/schemas/UserDetails'
+          title: User
       required:
       - access_token
       - refresh_token
@@ -401,9 +405,11 @@ components:
       properties:
         new_password1:
           type: string
+          title: New password1
           maxLength: 128
         new_password2:
           type: string
+          title: New password2
           maxLength: 128
       required:
       - new_password1
@@ -415,6 +421,7 @@ components:
         email:
           type: string
           format: email
+          title: Email
       required:
       - email
     PasswordResetConfirm:
@@ -423,14 +430,18 @@ components:
       properties:
         new_password1:
           type: string
+          title: New password1
           maxLength: 128
         new_password2:
           type: string
+          title: New password2
           maxLength: 128
         uid:
           type: string
+          title: Uid
         token:
           type: string
+          title: Token
       required:
       - new_password1
       - new_password2
@@ -443,38 +454,47 @@ components:
         pk:
           type: integer
           readOnly: true
+          title: ID
         username:
           type: string
           description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
+          title: Username
           pattern: ^[\w.@+-]+$
           maxLength: 150
         email:
           type: string
           format: email
           readOnly: true
+          title: Email address
         first_name:
           type: string
+          title: First name
           maxLength: 150
         last_name:
           type: string
+          title: Last name
           maxLength: 150
     Register:
       type: object
       properties:
         username:
           type: string
+          title: Username
           maxLength: 150
           minLength: 1
         email:
           type: string
           format: email
+          title: Email
         password1:
           type: string
           writeOnly: true
+          title: Password1
         password2:
           type: string
           writeOnly: true
+          title: Password2
       required:
       - password1
       - password2
@@ -485,6 +505,7 @@ components:
         detail:
           type: string
           readOnly: true
+          title: Detail
       required:
       - detail
     TokenRefresh:
@@ -492,6 +513,7 @@ components:
       properties:
         refresh:
           type: string
+          title: Refresh
       required:
       - refresh
     TokenVerify:
@@ -499,6 +521,7 @@ components:
       properties:
         token:
           type: string
+          title: Token
       required:
       - token
     UserDetails:
@@ -508,21 +531,26 @@ components:
         pk:
           type: integer
           readOnly: true
+          title: ID
         username:
           type: string
           description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
+          title: Username
           pattern: ^[\w.@+-]+$
           maxLength: 150
         email:
           type: string
           format: email
           readOnly: true
+          title: Email address
         first_name:
           type: string
+          title: First name
           maxLength: 150
         last_name:
           type: string
+          title: Last name
           maxLength: 150
       required:
       - email
@@ -533,6 +561,7 @@ components:
       properties:
         key:
           type: string
+          title: Key
       required:
       - key
   securitySchemes:

--- a/tests/contrib/test_rest_auth_token.yml
+++ b/tests/contrib/test_rest_auth_token.yml
@@ -386,11 +386,14 @@ components:
       properties:
         username:
           type: string
+          title: Username
         email:
           type: string
           format: email
+          title: Email
         password:
           type: string
+          title: Password
       required:
       - password
     PasswordChange:

--- a/tests/contrib/test_rest_polymorphic.yml
+++ b/tests/contrib/test_rest_polymorphic.yml
@@ -58,6 +58,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this person.
         required: true
       tags:
@@ -81,6 +82,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this person.
         required: true
       tags:
@@ -115,6 +117,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this person.
         required: true
       tags:
@@ -149,6 +152,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this person.
         required: true
       tags:
@@ -168,17 +172,21 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         company_name:
           type: string
+          title: Company name
           maxLength: 30
         address:
           type: string
+          title: Address
           maxLength: 30
         board:
           type: array
           items:
             $ref: '#/components/schemas/Person'
           readOnly: true
+          title: Board
       required:
       - address
       - board
@@ -190,17 +198,22 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         first_name:
           type: string
+          title: First name
           maxLength: 30
         last_name:
           type: string
+          title: Last name
           maxLength: 30
         address:
           type: string
+          title: Address
           maxLength: 30
         supervisor_id:
           type: integer
+          title: Supervisor id
           nullable: true
       required:
       - address
@@ -214,34 +227,43 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         company_name:
           type: string
+          title: Company name
           maxLength: 30
         address:
           type: string
+          title: Address
           maxLength: 30
         board:
           type: array
           items:
             $ref: '#/components/schemas/Person'
           readOnly: true
+          title: Board
     PatchedNaturalPerson:
       type: object
       properties:
         id:
           type: integer
           readOnly: true
+          title: ID
         first_name:
           type: string
+          title: First name
           maxLength: 30
         last_name:
           type: string
+          title: Last name
           maxLength: 30
         address:
           type: string
+          title: Address
           maxLength: 30
         supervisor_id:
           type: integer
+          title: Supervisor id
           nullable: true
     PatchedPerson:
       oneOf:

--- a/tests/contrib/test_simplejwt.yml
+++ b/tests/contrib/test_simplejwt.yml
@@ -82,9 +82,11 @@ components:
       properties:
         username:
           type: string
+          title: Username
         password:
           type: string
           writeOnly: true
+          title: Password
       required:
       - password
       - username
@@ -93,6 +95,7 @@ components:
       properties:
         refresh:
           type: string
+          title: Refresh
       required:
       - refresh
     X:
@@ -101,6 +104,7 @@ components:
         uuid:
           type: string
           format: uuid
+          title: Uuid
       required:
       - uuid
   securitySchemes:

--- a/tests/test_basic.yml
+++ b/tests/test_basic.yml
@@ -187,24 +187,32 @@ components:
           type: string
           format: uuid
           readOnly: true
+          title: Id
         songs:
           type: array
           items:
             $ref: '#/components/schemas/Song'
           readOnly: true
+          title: Songs
         single:
           allOf:
           - $ref: '#/components/schemas/Song'
           readOnly: true
+          title: Single
         title:
           type: string
+          title: Title
           maxLength: 100
         genre:
-          $ref: '#/components/schemas/GenreEnum'
+          allOf:
+          - $ref: '#/components/schemas/GenreEnum'
+          title: Genre
         year:
           type: integer
+          title: Year
         released:
           type: boolean
+          title: Released
       required:
       - genre
       - id
@@ -225,24 +233,32 @@ components:
           type: string
           format: uuid
           readOnly: true
+          title: Id
         songs:
           type: array
           items:
             $ref: '#/components/schemas/Song'
           readOnly: true
+          title: Songs
         single:
           allOf:
           - $ref: '#/components/schemas/Song'
           readOnly: true
+          title: Single
         title:
           type: string
+          title: Title
           maxLength: 100
         genre:
-          $ref: '#/components/schemas/GenreEnum'
+          allOf:
+          - $ref: '#/components/schemas/GenreEnum'
+          title: Genre
         year:
           type: integer
+          title: Year
         released:
           type: boolean
+          title: Released
     Song:
       type: object
       properties:
@@ -250,15 +266,19 @@ components:
           type: string
           format: uuid
           readOnly: true
+          title: Id
         title:
           type: string
+          title: Title
           maxLength: 100
         length:
           type: integer
+          title: Length
         top10:
           type: boolean
           nullable: true
           readOnly: true
+          title: Top10
       required:
       - id
       - length

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -198,6 +198,7 @@ paths:
         schema:
           type: string
           description: filter by containing string
+          title: Contains
           maxLength: 10
           minLength: 3
       - in: query
@@ -213,6 +214,7 @@ paths:
             - a
             - b
             type: string
+          title: Order by
       - in: query
         name: stars
         schema:
@@ -220,6 +222,7 @@ paths:
           maximum: 5
           minimum: 1
           description: filter by rating stars
+          title: Stars
         required: true
       tags:
       - doesitall
@@ -241,8 +244,10 @@ components:
       properties:
         field_a:
           type: string
+          title: Field a
         field_b:
           type: integer
+          title: Field b
       required:
       - field_a
       - field_b
@@ -251,11 +256,14 @@ components:
       properties:
         field_a:
           type: string
+          title: Field a
         field_b:
           type: integer
+          title: Field b
         field_c:
           type: object
           additionalProperties: {}
+          title: Field c
       required:
       - field_a
       - field_b
@@ -265,8 +273,10 @@ components:
       properties:
         field_a:
           type: string
+          title: Field a
         field_b:
           type: integer
+          title: Field b
     ErrorDetail:
       type: object
       properties:
@@ -274,20 +284,24 @@ components:
           type: string
           format: date-time
           readOnly: true
+          title: Field i
         field_j:
           allOf:
           - $ref: '#/components/schemas/Inline'
           nullable: true
           readOnly: true
+          title: Field j
         field_k:
           type: array
           items:
             $ref: '#/components/schemas/Inline'
           readOnly: true
+          title: Field k
         field_l:
           allOf:
           - $ref: '#/components/schemas/FieldLEnum'
           readOnly: true
+          title: Field l
       required:
       - field_i
       - field_j
@@ -303,6 +317,7 @@ components:
       properties:
         encoding:
           type: string
+          title: Encoding
         image_data:
           type: string
           format: byte
@@ -314,8 +329,10 @@ components:
       properties:
         inline_b:
           type: boolean
+          title: Inline b
         inline_i:
           type: integer
+          title: Inline i
       required:
       - inline_b
       - inline_i
@@ -327,9 +344,11 @@ components:
           maximum: 5
           minimum: 1
           description: filter by rating stars
+          title: Stars
         contains:
           type: string
           description: filter by containing string
+          title: Contains
           maxLength: 10
           minLength: 3
         order_by:
@@ -341,6 +360,7 @@ components:
             type: string
           default:
           - a
+          title: Order by
       required:
       - stars
   securitySchemes:

--- a/tests/test_extend_schema_view.yml
+++ b/tests/test_extend_schema_view.yml
@@ -31,6 +31,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this esv model.
         required: true
       tags:
@@ -136,6 +137,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this esv model.
         required: true
       tags:
@@ -159,6 +161,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this esv model.
         required: true
       tags:
@@ -193,6 +196,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this esv model.
         required: true
       tags:
@@ -227,6 +231,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this esv model.
         required: true
       tags:
@@ -246,6 +251,7 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
       required:
       - id
     PatchedESV:
@@ -254,6 +260,7 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
   securitySchemes:
     basicAuth:
       type: http

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -31,6 +31,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this all fields.
         required: true
       tags:
@@ -98,155 +99,200 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         field_decimal_uncoerced:
           type: number
           format: double
           maximum: 1000
           minimum: -1000
+          title: Field decimal uncoerced
         field_method_float:
           type: number
           format: float
           readOnly: true
+          title: Field method float
         field_method_object:
           type: object
           additionalProperties: {}
           readOnly: true
+          title: Field method object
         field_regex:
           type: string
+          title: Field regex
           pattern: ^[a-zA-z0-9]{10}\-[a-z]
         field_list:
           type: array
           items:
             type: number
             format: float
+          title: Field list
           maxItems: 100
           minItems: 3
         field_list_serializer:
           type: array
           items:
             $ref: '#/components/schemas/Aux'
+          title: Field list serializer
         field_related_slug:
           type: string
           readOnly: true
+          title: Field related slug
         field_related_string:
           type: string
           readOnly: true
+          title: Field related string
         field_related_hyperlink:
           type: string
           format: uri
           readOnly: true
+          title: Field related hyperlink
         field_identity_hyperlink:
           type: string
           format: uri
           readOnly: true
+          title: Field identity hyperlink
         field_read_only_nav_uuid:
           type: string
           format: uuid
           readOnly: true
+          title: Field read only nav uuid
         field_read_only_nav_uuid_3steps:
           type: string
           format: uuid
           readOnly: true
           nullable: true
+          title: Field read only nav uuid 3steps
         field_read_only_model_function_basic:
           type: boolean
           readOnly: true
+          title: Field read only model function basic
         field_read_only_model_function_model:
           type: string
           format: uuid
           readOnly: true
+          title: Field read only model function model
         field_bool_override:
           type: boolean
           readOnly: true
+          title: Field bool override
         field_model_property_float:
           type: number
           format: float
           readOnly: true
+          title: Field model property float
         field_dict_int:
           type: object
           additionalProperties:
             type: integer
+          title: Field dict int
         field_json:
           type: object
           additionalProperties: {}
+          title: Field json
         field_int:
           type: integer
+          title: Field int
         field_float:
           type: number
           format: float
+          title: Field float
         field_bool:
           type: boolean
+          title: Field bool
         field_char:
           type: string
+          title: Field char
           maxLength: 100
         field_text:
           type: string
+          title: Field text
         field_slug:
           type: string
+          title: Field slug
           maxLength: 50
           pattern: ^[-a-zA-Z0-9_]+$
         field_email:
           type: string
           format: email
+          title: Field email
           maxLength: 254
         field_uuid:
           type: string
           format: uuid
+          title: Field uuid
         field_url:
           type: string
           format: uri
+          title: Field url
           maxLength: 200
         field_ip:
           type: string
+          title: Field ip
         field_ip_generic:
           type: string
+          title: Field ip generic
         field_decimal:
           type: string
           format: decimal
           maximum: 1000
           minimum: -1000
+          title: Field decimal
         field_file:
           type: string
           format: uri
+          title: Field file
         field_img:
           type: string
           format: uri
+          title: Field img
         field_date:
           type: string
           format: date
+          title: Field date
         field_datetime:
           type: string
           format: date-time
+          title: Field datetime
         field_bigint:
           type: integer
+          title: Field bigint
         field_smallint:
           type: integer
+          title: Field smallint
         field_posint:
           type: integer
+          title: Field posint
         field_possmallint:
           type: integer
+          title: Field possmallint
         field_nullbool:
           type: boolean
           nullable: true
+          title: Field nullbool
         field_time:
           type: string
           format: time
+          title: Field time
         field_duration:
           type: string
+          title: Field duration
         field_foreign:
           type: string
           format: uuid
           description: main aux object
+          title: Field foreign
         field_o2o:
           type: string
           format: uuid
           description: bound aux object
+          title: Field o2o
         field_m2m:
           type: array
           items:
             type: string
             format: uuid
           description: set of related aux objects
+          title: Field m2m
       required:
       - field_bigint
       - field_bool
@@ -300,10 +346,12 @@ components:
           type: string
           format: uuid
           readOnly: true
+          title: Id
         field_foreign:
           type: string
           format: uuid
           nullable: true
+          title: Field foreign
       required:
       - id
   securitySchemes:

--- a/tests/test_i18n.yml
+++ b/tests/test_i18n.yml
@@ -106,6 +106,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this Internätiönalisierung.
         required: true
       tags:
@@ -129,8 +130,10 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         field_str:
           type: string
+          title: Field str
       required:
       - field_str
       - id

--- a/tests/test_polymorphic.yml
+++ b/tests/test_polymorphic.yml
@@ -39,12 +39,15 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         company_name:
           type: string
+          title: Company name
           maxLength: 30
         type:
           type: string
           readOnly: true
+          title: Type
       required:
       - company_name
       - id
@@ -64,15 +67,19 @@ components:
         id:
           type: integer
           readOnly: true
+          title: ID
         first_name:
           type: string
+          title: First name
           maxLength: 30
         last_name:
           type: string
+          title: Last name
           maxLength: 30
         type:
           type: string
           readOnly: true
+          title: Type
       required:
       - first_name
       - id

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -68,8 +68,8 @@ def test_global_enum_naming_override(no_warnings):
         serializer_class = XSerializer
 
     schema = generate_schema('/x', view=XView)
-    assert 'LanguageEnum' in schema['components']['schemas']['X']['properties']['foo']['$ref']
-    assert 'LanguageEnum' in schema['components']['schemas']['X']['properties']['bar']['$ref']
+    assert 'LanguageEnum' in schema['components']['schemas']['X']['properties']['foo']['allOf'][0]['$ref']
+    assert 'LanguageEnum' in schema['components']['schemas']['X']['properties']['bar']['allOf'][0]['$ref']
     assert len(schema['components']['schemas']) == 2
 
 
@@ -150,8 +150,8 @@ def test_enum_resolvable_collision_with_patched_and_request_splits():
     schema = generate_schema('/x', XViewset)
     components = schema['components']['schemas']
     assert 'XFooEnum' in components and 'YFooEnum' in components
-    assert '/XFooEnum' in components['XRequest']['properties']['foo']['$ref']
-    assert '/XFooEnum' in components['PatchedXRequest']['properties']['foo']['$ref']
+    assert '/XFooEnum' in components['XRequest']['properties']['foo']['allOf'][0]['$ref']
+    assert '/XFooEnum' in components['PatchedXRequest']['properties']['foo']['allOf'][0]['$ref']
 
 
 def test_enum_override_variations(no_warnings):

--- a/tests/test_postprocessing.yml
+++ b/tests/test_postprocessing.yml
@@ -45,7 +45,9 @@ components:
       type: object
       properties:
         language:
-          $ref: '#/components/schemas/LanguageEnum'
+          allOf:
+          - $ref: '#/components/schemas/LanguageEnum'
+          title: Language
       required:
       - language
     B:
@@ -53,6 +55,7 @@ components:
       properties:
         language:
           nullable: true
+          title: Language
           oneOf:
           - $ref: '#/components/schemas/LanguageEnum'
           - $ref: '#/components/schemas/BlankEnum'

--- a/tests/test_recursion.yml
+++ b/tests/test_recursion.yml
@@ -37,16 +37,20 @@ components:
           type: string
           format: uuid
           readOnly: true
+          title: Id
         label:
           type: string
+          title: Label
         parent:
           type: string
           format: uuid
           nullable: true
+          title: Parent
         children:
           type: array
           items:
             $ref: '#/components/schemas/TreeNode'
+          title: Children
       required:
       - children
       - id

--- a/tests/test_versioning_accept_v1.yml
+++ b/tests/test_versioning_accept_v1.yml
@@ -31,6 +31,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this versioning model.
         required: true
       tags:
@@ -53,6 +54,7 @@ components:
       properties:
         id:
           type: integer
+          title: Id
       required:
       - id
   securitySchemes:

--- a/tests/test_versioning_accept_v2.yml
+++ b/tests/test_versioning_accept_v2.yml
@@ -31,6 +31,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this versioning model.
         required: true
       tags:
@@ -54,6 +55,7 @@ components:
         id:
           type: string
           format: uuid
+          title: Id
       required:
       - id
   securitySchemes:

--- a/tests/test_versioning_v1.yml
+++ b/tests/test_versioning_v1.yml
@@ -31,6 +31,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this versioning model.
         required: true
       tags:
@@ -53,6 +54,7 @@ components:
       properties:
         id:
           type: integer
+          title: Id
       required:
       - id
   securitySchemes:

--- a/tests/test_versioning_v2.yml
+++ b/tests/test_versioning_v2.yml
@@ -31,6 +31,7 @@ paths:
         name: id
         schema:
           type: integer
+          title: ID
         description: A unique integer value identifying this versioning model.
         required: true
       tags:
@@ -54,6 +55,7 @@ components:
         id:
           type: string
           format: uuid
+          title: Id
       required:
       - id
   securitySchemes:


### PR DESCRIPTION
This PR adds the `title` keyword of a DRF serializer field to `properties` schema.
The usage is to expose and maintain a more descriptive name of the field in the backend.
This can be used in the frontend e.g. for the label of a formfield or the headerline of a table. 

The keyword is derived from the DRF serializer field attribute `label`. In case of `ModelSerializer` it is extracted from the model field attribute `verbose_name`.

References #140