### PR TITLE
added type extension for int64 format support

### DIFF
--- a/drf_spectacular/types.py
+++ b/drf_spectacular/types.py
@@ -21,6 +21,7 @@ class OpenApiTypes(enum.Enum):
     BINARY = enum.auto()
     PASSWORD = enum.auto()
     INT = enum.auto()
+    INT64 = enum.auto()
     UUID = enum.auto()
     URI = enum.auto()
     IP4 = enum.auto()
@@ -44,6 +45,7 @@ OPENAPI_TYPE_MAPPING = {
     OpenApiTypes.BINARY: {'type': 'string', 'format': 'binary'},
     OpenApiTypes.PASSWORD: {'type': 'string', 'format': 'password'},
     OpenApiTypes.INT: {'type': 'integer'},
+    OpenApiTypes.INT64: {'type': 'integer', 'format': 'int64'},
     OpenApiTypes.UUID: {'type': 'string', 'format': 'uuid'},
     OpenApiTypes.URI: {'type': 'string', 'format': 'uri'},
     OpenApiTypes.IP4: {'type': 'string', 'format': 'ipv4'},


### PR DESCRIPTION
Hi,
for a current project I need to be able to explicitly declare an integer value with format int64. As I didn't find a workaround, I did a minimal code extension to drf-spectacular to provide this. 

I currently use this with such sample code:

```
class BigIntegerFieldFix(OpenApiSerializerFieldExtension):
    """fix serializer field BigIntegerField beeing reported as type integer, format int64 by spectacular"""
    target_class = 'restapi.serializers.BigIntegerField'

    def map_serializer_field(self, auto_schema, direction):
        return build_basic_type(OpenApiTypes.INT64)


class BigIntegerField(serializers.IntegerField):
    """dummy serializer field implementation to have spectacular make this type integer, format int64 in schema"""
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
```

in my drf serializers.  Maybe, this is somewhat usefull for others, too.

