### PR TITLE
Fix enum postprocessor to allow 0 as possible value

### DIFF
--- a/drf_spectacular/hooks.py
+++ b/drf_spectacular/hooks.py
@@ -56,7 +56,7 @@ def postprocess_schema_enums(result, generator, **kwargs):
             if 'enum' not in prop_schema:
                 continue
             # remove blank/null entry for hashing. will be reconstructed in the last step
-            prop_enum_cleaned_hash = list_hash([i for i in prop_schema['enum'] if i])
+            prop_enum_cleaned_hash = list_hash([i for i in prop_schema['enum'] if i not in ['', None]])
             prop_hash_mapping[prop_name].add(prop_enum_cleaned_hash)
             hash_name_mapping[prop_enum_cleaned_hash].add((component_name, prop_name))
 
@@ -102,7 +102,7 @@ def postprocess_schema_enums(result, generator, **kwargs):
                 continue
 
             prop_enum_original_list = prop_schema['enum']
-            prop_schema['enum'] = [i for i in prop_schema['enum'] if i]
+            prop_schema['enum'] = [i for i in prop_schema['enum'] if i not in ['', None]]
             prop_hash = list_hash(prop_schema['enum'])
             # when choice sets are reused under multiple names, the generated name cannot be
             # resolved from the hash alone. fall back to prop_name and hash for resolution.

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -22,6 +22,12 @@ language_choices = (
     ('cn', 'cn'),
 )
 
+vote_choices = (
+    (1, 'Positive'),
+    (0, 'Neutral'),
+    (-1, 'Negative'),
+)
+
 language_list = ['en']
 
 
@@ -35,6 +41,7 @@ class LanguageChoices(Choices):
 
 class ASerializer(serializers.Serializer):
     language = serializers.ChoiceField(choices=language_choices)
+    vote = serializers.ChoiceField(choices=vote_choices)
 
 
 class BSerializer(serializers.Serializer):

--- a/tests/test_postprocessing.yml
+++ b/tests/test_postprocessing.yml
@@ -46,8 +46,11 @@ components:
       properties:
         language:
           $ref: '#/components/schemas/LanguageEnum'
+        vote:
+          $ref: '#/components/schemas/VoteEnum'
       required:
       - language
+      - vote
     B:
       type: object
       properties:
@@ -72,6 +75,12 @@ components:
     NullEnum:
       enum:
       - null
+    VoteEnum:
+      enum:
+      - 1
+      - 0
+      - -1
+      type: integer
   securitySchemes:
     basicAuth:
       type: http


### PR DESCRIPTION
Enum post processor skips 0 while excluding falsy values in the enum list. This makes 0 disappear from a valid integer enum.

Instead of checking for falsy values, explicitly skip empty string and None from enum choices.