### PR TITLE
Create new mock request on each operation

### DIFF
--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -157,10 +157,9 @@ class SchemaGenerator(BaseSchemaGenerator):
 
             # mocked request to allow certain operations in get_queryset and get_serializer[_class]
             # without exceptions being raised due to no request.
-            if not request:
-                request = spectacular_settings.GET_MOCK_REQUEST(method, path, view, request)
+            mock_request = spectacular_settings.GET_MOCK_REQUEST(method, path, view, request)
 
-            view.request = request
+            view.request = mock_request
 
             if view.versioning_class and not is_versioning_supported(view.versioning_class):
                 warn(
@@ -170,7 +169,7 @@ class SchemaGenerator(BaseSchemaGenerator):
             elif view.versioning_class:
                 version = (
                     self.api_version  # generator was explicitly versioned
-                    or getattr(request, 'version', None)  # incoming request was versioned
+                    or getattr(mock_request, 'version', None)  # incoming request was versioned
                     or view.versioning_class.default_version  # fallback
                 )
                 if not version:


### PR DESCRIPTION
We have come across a few instances where views, filter backends etc. access properties of the request, for example the HTTP method. Since the mock request is only created on the first iteration, request path and method are identical for all following operations.

This PR changes the generator so that it creates a fresh mock request for each operation, avoiding further issues with introspection.