### PR TITLE
Modify urls for nested routers

### DIFF
--- a/tests/test_extend_schema_view.py
+++ b/tests/test_extend_schema_view.py
@@ -1,5 +1,6 @@
 import pytest
 from django.db import models
+from django.urls import path
 from rest_framework import mixins, routers, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -15,9 +16,19 @@ class ESVModel(models.Model):
     pass
 
 
+class ESVSubModel(models.Model):
+    esv = models.ForeignKey(ESVModel, on_delete=models.CASCADE)
+
+
 class ESVSerializer(serializers.ModelSerializer):
     class Meta:
         model = ESVModel
+        fields = '__all__'
+
+
+class ESVSubSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ESVSubModel
         fields = '__all__'
 
 
@@ -46,6 +57,15 @@ class XViewset(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Generi
         return Response('2019-03-01')
 
 
+class XNestedViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    queryset = ESVSubModel.objects.all()
+    serializer_class = ESVSubSerializer
+
+    @extend_schema(tags=['nested-retrieve-tag'])
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
+
 # view to make sure there is no cross-talk
 class YViewSet(viewsets.ModelViewSet):
     serializer_class = ESVSerializer
@@ -55,7 +75,9 @@ class YViewSet(viewsets.ModelViewSet):
 router = routers.SimpleRouter()
 router.register('x', XViewset)
 router.register('y', YViewSet)
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path('/xy/{esv_pk}/nested_action/{pk}/', XNestedViewset.as_view({'get': 'retrieve'})),
+]
 
 
 @pytest.mark.urls(__name__)

--- a/tests/test_extend_schema_view.yml
+++ b/tests/test_extend_schema_view.yml
@@ -81,6 +81,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/ESV'
           description: ''
+  /xy/{esv_id}/nested_action/{id}/:
+    get:
+      operationId: xy_nested_action_retrieve
+      description: ''
+      parameters:
+      - in: path
+        name: esv_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this esv sub model.
+        required: true
+      tags:
+      - nested-retrieve-tag
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ESVSub'
+          description: ''
   /y/:
     get:
       operationId: y_list
@@ -247,6 +276,17 @@ components:
           type: integer
           readOnly: true
       required:
+      - id
+    ESVSub:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        esv:
+          type: integer
+      required:
+      - esv
       - id
     PatchedESV:
       type: object


### PR DESCRIPTION
drf-spectacular uses the `coerce_path` method of the Django Rest Framework, replacing `pk` path parameters with `id` (or the appropriate primary key). When using the `drf-nested-routers` library for extending URL actions to related objects, auto-generated URL paths are created with `{object_pk}` patterns.

Since these are not valid fields on the queryet model, they require a manual definition of URL path parameters using `@extend_schema`. This PR replaces such `_pk` suffixes with `_id` (or the appropriate primary key), so that further introspection is also able to guess the parameter type.

The included test is based on a manually-created URL path, since it seemed unnecessary to add nested-routers as a dependency just for this purpose.