### PR TITLE
Add support for SCOPES_BACKEND_CLASS setting from django-oauth-toolkit

### DIFF
--- a/drf_spectacular/contrib/django_oauth_toolkit.py
+++ b/drf_spectacular/contrib/django_oauth_toolkit.py
@@ -27,7 +27,7 @@ class DjangoOAuthToolkitScheme(OpenApiAuthenticationExtension):
                 return {self.name: permission.get_scopes(request, view)}
 
     def get_security_definition(self, auto_schema):
-        from oauth2_provider.settings import oauth2_settings
+        from oauth2_provider.scopes import get_scopes_backend
 
         from drf_spectacular.settings import spectacular_settings
 
@@ -40,8 +40,8 @@ class DjangoOAuthToolkitScheme(OpenApiAuthenticationExtension):
                 flows[flow_type]['tokenUrl'] = spectacular_settings.OAUTH2_TOKEN_URL
             if spectacular_settings.OAUTH2_REFRESH_URL:
                 flows[flow_type]['refreshUrl'] = spectacular_settings.OAUTH2_REFRESH_URL
-            if oauth2_settings.SCOPES:
-                flows[flow_type]['scopes'] = oauth2_settings.SCOPES
+            scope_backend = get_scopes_backend()
+            flows[flow_type]['scopes'] = scope_backend.get_all_scopes()
 
         return {
             'type': 'oauth2',

--- a/tests/contrib/test_oauth_toolkit.py
+++ b/tests/contrib/test_oauth_toolkit.py
@@ -51,12 +51,6 @@ class TestScopesBackend(BaseScopes):
     def get_all_scopes(self):
         return ['test_backend_scope']
 
-    def get_available_scopes(self, application=None, request=None, *args, **kwargs):
-        return ['test_backend_scope']
-
-    def get_default_scopes(self, application=None, request=None, *args, **kwargs):
-        return ['test_backend_scope']
-
 
 @mock.patch(
     'drf_spectacular.settings.spectacular_settings.OAUTH2_FLOWS',

--- a/tests/contrib/test_oauth_toolkit.py
+++ b/tests/contrib/test_oauth_toolkit.py
@@ -7,6 +7,7 @@ from rest_framework import mixins, routers, serializers, viewsets
 from rest_framework.authentication import BasicAuthentication
 
 from drf_spectacular.generators import SchemaGenerator
+from drf_spectacular.validation import validate_schema
 from tests import assert_schema
 
 try:
@@ -49,7 +50,7 @@ class IsAuthenticatedOrTokenHasScopeViewset(mixins.ListModelMixin, viewsets.Gene
 class TestScopesBackend(BaseScopes):
 
     def get_all_scopes(self):
-        return ['test_backend_scope']
+        return {'test_backend_scope': 'Test scope for ScopesBackend'}
 
 
 @mock.patch(
@@ -118,9 +119,10 @@ def test_oauth2_toolkit_scopes_backend(no_warnings):
 
     generator = SchemaGenerator(patterns=urlpatterns)
     schema = generator.get_schema(request=None, public=True)
+    validate_schema(schema)
 
     assert 'oauth2' in schema['components']['securitySchemes']
     oauth2 = schema['components']['securitySchemes']['oauth2']
     assert 'implicit' in oauth2['flows']
     flow = oauth2['flows']['implicit']
-    assert flow['scopes'] == ['test_backend_scope']
+    assert 'test_backend_scope' in flow['scopes']

--- a/tests/contrib/test_oauth_toolkit.py
+++ b/tests/contrib/test_oauth_toolkit.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from django.urls import include, path
+from oauth2_provider.scopes import BaseScopes
 from rest_framework import mixins, routers, serializers, viewsets
 from rest_framework.authentication import BasicAuthentication
 
@@ -45,6 +46,18 @@ class IsAuthenticatedOrTokenHasScopeViewset(mixins.ListModelMixin, viewsets.Gene
     required_scopes = ['extra_scope']
 
 
+class TestScopesBackend(BaseScopes):
+
+    def get_all_scopes(self):
+        return ['test_backend_scope']
+
+    def get_available_scopes(self, application=None, request=None, *args, **kwargs):
+        return ['test_backend_scope']
+
+    def get_default_scopes(self, application=None, request=None, *args, **kwargs):
+        return ['test_backend_scope']
+
+
 @mock.patch(
     'drf_spectacular.settings.spectacular_settings.OAUTH2_FLOWS',
     ['implicit']
@@ -81,3 +94,39 @@ def test_oauth2_toolkit(no_warnings):
     schema = generator.get_schema(request=None, public=True)
 
     assert_schema(schema, 'tests/contrib/test_oauth_toolkit.yml')
+
+
+@mock.patch(
+    'drf_spectacular.settings.spectacular_settings.OAUTH2_FLOWS',
+    ['implicit']
+)
+@mock.patch(
+    'drf_spectacular.settings.spectacular_settings.OAUTH2_REFRESH_URL',
+    'http://127.0.0.1:8000/o/refresh'
+)
+@mock.patch(
+    'drf_spectacular.settings.spectacular_settings.OAUTH2_AUTHORIZATION_URL',
+    'http://127.0.0.1:8000/o/authorize'
+)
+@mock.patch(
+    'oauth2_provider.settings.oauth2_settings.SCOPES_BACKEND_CLASS',
+    TestScopesBackend,
+)
+@pytest.mark.contrib('oauth2_provider')
+def test_oauth2_toolkit_scopes_backend(no_warnings):
+    router = routers.SimpleRouter()
+    router.register('TokenHasReadWriteScope', TokenHasReadWriteScopeViewset, basename='x')
+
+    urlpatterns = [
+        *router.urls,
+        path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    ]
+
+    generator = SchemaGenerator(patterns=urlpatterns)
+    schema = generator.get_schema(request=None, public=True)
+
+    assert 'oauth2' in schema['components']['securitySchemes']
+    oauth2 = schema['components']['securitySchemes']['oauth2']
+    assert 'implicit' in oauth2['flows']
+    flow = oauth2['flows']['implicit']
+    assert flow['scopes'] == ['test_backend_scope']


### PR DESCRIPTION
In Version 0.12.0 django-oauth-toolkit added the [`SCOPES_BACKED_CLASS` setting](https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#scopes-backend-class), which allows customizing the logic for oauth scopes. drf-spectacular currently ignores this setting.
A fallback to reading the `SCOPES` setting is imho not needed, because a) Version 0.11.0 is from 2016, so hopefully nobody is still using that and b) `SCOPES_BACKEND_CLASS` has a default of `SettingsScopes`, which reads the previous `SCOPES` setting.