### PR TITLE
Use explicit declared serializer field label as oas title

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -693,6 +693,8 @@ class AutoSchema(ViewInspector):
             if isinstance(default, set):
                 default = list(default)
             meta['default'] = default
+        if field._kwargs.get('label'):
+            meta['title'] = field._kwargs['label']
         if field.help_text:
             meta['description'] = str(field.help_text)
         return meta


### PR DESCRIPTION
NOTE: every serializer field has a non-empty label, when not declared it's derived from the field name. I think only explicitly declared labels are necessary to go into the OAS schema. So I read the label from `field._kwargs`, not `field.label`.