### PR TITLE
README.rst encoding change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Requirements
 Installation
 ------------
 
-Install using ``pip``\ …
+Install using ``pip``\ ...
 
 .. code:: bash
 


### PR DESCRIPTION
## Proplems

1. README.rst file is utf-8 charset, so a problem occurs when using tox

## Changes 

1.README.rst Change utf-8 charset to ascii charset

## Result

Before 

```
$ python -m tox
GLOB sdist-make: C:\git\drf-spectacular\setup.py
ERROR: invocation failed (exit code 1), logfile: C:\git\drf-spectacular\.tox\log\GLOB-0.log
=============================================== log start ================================================
Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    long_description = readme.read()
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 3330: illegal multibyte sequence      

================================================ log end =================================================
```

After

```
$ python -m tox
GLOB sdist-make: C:\git\drf-spectacular\setup.py
lint inst-nodeps: C:\git\drf-spectacular\.tox\.tmp\package\1\drf-spectacular-0.13.1.zip
```