### PR TITLE
Serializer field description

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -154,6 +154,7 @@ class AutoSchema(ViewInspector):
                     result[property_name, OpenApiParameter.QUERY] = build_parameter_type(
                         name=property_name,
                         schema=property_schema,
+                        description=property_schema.get('description', None),
                         location=OpenApiParameter.QUERY,
                         required=property_name in mapped.get('required', []),
                     )

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -154,7 +154,7 @@ class AutoSchema(ViewInspector):
                     result[property_name, OpenApiParameter.QUERY] = build_parameter_type(
                         name=property_name,
                         schema=property_schema,
-                        description=property_schema.get('description', None),
+                        description=property_schema.pop('description', None),
                         location=OpenApiParameter.QUERY,
                         required=property_name in mapped.get('required', []),
                     )

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -219,6 +219,7 @@ paths:
           description: filter by containing string
           maxLength: 10
           minLength: 3
+        description: filter by containing string
       - in: query
         name: nested
         schema:
@@ -242,6 +243,7 @@ paths:
           maximum: 5
           minimum: 1
           description: filter by rating stars
+        description: filter by rating stars
         required: true
       tags:
       - doesitall

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -216,7 +216,6 @@ paths:
         name: contains
         schema:
           type: string
-          description: filter by containing string
           maxLength: 10
           minLength: 3
         description: filter by containing string
@@ -242,7 +241,6 @@ paths:
           type: integer
           maximum: 5
           minimum: 1
-          description: filter by rating stars
         description: filter by rating stars
         required: true
       tags:


### PR DESCRIPTION
Serializer help_text parameter is extracted and used in property_schema.
Now Serializer help_text field fills the Redoc documentation query parameter but SwaggerUI is doesn't use it.
Grab the value from property_schema and pass it to the parameter.
