### PR TITLE
Add document authentication

### DIFF
--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -27,6 +27,7 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # is the
     'SERVE_INCLUDE_SCHEMA': True,
     'SERVE_PERMISSIONS': ['rest_framework.permissions.AllowAny'],
+    'SERVE_AUTHENTICATION': None,
 
     # Dictionary of configurations to pass to the SwaggerUI({ ... })
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from drf_spectacular.plumbing import get_relative_url, set_query_parameters
@@ -42,6 +43,7 @@ class SpectacularAPIView(APIView):
         OpenApiYamlRenderer, OpenApiYamlRenderer2, OpenApiJsonRenderer, OpenApiJsonRenderer2
     ]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
+    authentication_classes = spectacular_settings.SERVE_AUTHENTICATION or api_settings.DEFAULT_AUTHENTICATION_CLASSES
 
     generator_class = spectacular_settings.DEFAULT_GENERATOR_CLASS
     serve_public = spectacular_settings.SERVE_PUBLIC
@@ -76,6 +78,7 @@ class SpectacularJSONAPIView(SpectacularAPIView):
 class SpectacularSwaggerView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
+    authentication_classes = spectacular_settings.SERVE_AUTHENTICATION or api_settings.DEFAULT_AUTHENTICATION_CLASSES
     url_name = 'schema'
     url = None
     template_name = 'drf_spectacular/swagger_ui.html'
@@ -140,6 +143,7 @@ class SpectacularSwaggerSplitView(SpectacularSwaggerView):
 class SpectacularRedocView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
+    authentication_classes = spectacular_settings.SERVE_AUTHENTICATION or api_settings.DEFAULT_AUTHENTICATION_CLASSES
     url_name = 'schema'
     url = None
     template_name = 'drf_spectacular/redoc.html'


### PR DESCRIPTION
## Proplems

1. The documentation authentication method is specified as drf DEFAULT_AUTHENTICATION_CLASSES, which prevents the use of other authentication methods. (There is a way to use it by inheriting the class, but I think it is better to set it in SPECTACULAR_SETTINGS like SERVE_PERMISSIONS.)

## Result

If you follow the example and set it up, it's over. Even if SERVE_AUTHENTICATION is not specified, it is applied to the DRF as DEFAULT_AUTHENTICATION_CLASSES.<br/>
settings.py 
```
SPECTACULAR_SETTINGS = {
    'SERVE_AUTHENTICATION': ['rest_framework.authentication.SessionAuthentication'],
}
