### PR TITLE
Fix for better support of PEP 563 compatible annotations.

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -360,9 +360,9 @@ def _follow_field_source(model, path: List[str]):
     else:
         if isinstance(field_or_property, property) or callable(field_or_property):
             if isinstance(field_or_property, property):
-                target_model = field_or_property.fget.__annotations__.get('return')
+                target_model = typing.get_type_hints(field_or_property.fget).get('return')
             else:
-                target_model = field_or_property.__annotations__.get('return')
+                target_model = typing.get_type_hints(field_or_property).get('return')
             if not target_model:
                 raise UnableToProceedError(
                     f'could not follow field source through intermediate property "{path[0]}" '


### PR DESCRIPTION
See [PEP-563](https://www.python.org/dev/peps/pep-0563/).
There were a couple of stray places using `__annotations__` instead of of `typing.get_type_hints()`. This meant type resolving failed if you were using `from __future__ import annotations`, or string annotations, or using Python 3.10 where the new behaviour will be enforced.

I had a look at writing a test for this, but it is very hard with the current test setup. 

In particular, the current method of [injecting different type hints into the test](https://github.com/tfranzel/drf-spectacular/blob/6b53554c8c09a764fb193143fed12505b3de4af9/tests/test_plumbing.py#L166) will not work at all under Python 3.10 or `from __future__ import annotations`, due to essential changes in syntax/parsing. You get lots of `NameError: name 'type_hint' is not defined` in `test_type_hint_extraction`.

So, these tests will need to be rewritten somehow for Python 3.10, I don't know how. In the meantime, this patch should help those of us who need to use string annotations (or from __future__ import annotations`) as I do in a few places due to cyclic references. Hopefully it can be merged without tests!

