### PR TITLE
Add any type for OpenApiTypes

### DIFF
--- a/drf_spectacular/types.py
+++ b/drf_spectacular/types.py
@@ -1,4 +1,5 @@
 import enum
+import typing
 from datetime import date, datetime
 from decimal import Decimal
 from uuid import UUID
@@ -39,6 +40,7 @@ class OpenApiTypes(enum.Enum):
     EMAIL = enum.auto()
     OBJECT = enum.auto()
     NONE = enum.auto()
+    ANY = enum.auto()
 
 
 def build_generic_type():
@@ -74,6 +76,13 @@ OPENAPI_TYPE_MAPPING = {
     OpenApiTypes.TIME: {'type': 'string', 'format': 'time'},
     OpenApiTypes.EMAIL: {'type': 'string', 'format': 'email'},
     OpenApiTypes.OBJECT: build_generic_type(),
+    OpenApiTypes.ANY: {'anyOf': [
+        {'type': 'string'},
+        {'type': 'number'}, 
+        {'type': 'boolean'}, 
+        {'type': 'array', 'items': {}},
+        {'type': 'object'}
+    ]},
     OpenApiTypes.NONE: {},
 }
 
@@ -89,6 +98,7 @@ PYTHON_TYPE_MAPPING = {
     datetime: OpenApiTypes.DATETIME,
     date: OpenApiTypes.DATE,
     dict: OpenApiTypes.OBJECT,
+    typing.Any: OpenApiTypes.ANY,
     None: OpenApiTypes.NONE,
 }
 


### PR DESCRIPTION
This PR adds an ANY type according to:
https://swagger.io/docs/specification/data-models/data-types/#mixed-type and 
https://swagger.io/docs/specification/data-models/data-types/#any

Reason for this: 
I recently implemented a SerializerMethodField which had ANY type. and in the class [OpenApiTypes](https://github.com/tfranzel/drf-spectacular/blob/master/drf_spectacular/types.py#L9), this type was missing. for me it would be nice to have it in the future. 