### PR TITLE
Update django_filters.py to allow None in EnumField for python 3

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -98,7 +98,7 @@ class DjangoFilterExtension(OpenApiFilterExtension):
         enum = schema.pop('enum', None)
         if 'choices' in filter_field.extra:
             enum = [c for c, _ in filter_field.extra['choices']]
-        if enum:
+        if enum and None not in enum:
             schema['enum'] = sorted(enum, key=str)
 
         description = schema.pop('description', None)


### PR DESCRIPTION
Issue: 
If field has `choices` and `null=True` as the same time. `enum` list will have mixed types of `NoneType` and a primitive type (`str`, `int`).
Example: 
```
field = models.CharField(max_length=10, choices = {'a':'A', 'b':'B'}, null=True, blank=True)
```
```
enum = ['a', 'b', None]
```
Under python3 `sorted` will return exception for this array. So either ignore the sorting for those or we have to find a proper value for None
https://stackoverflow.com/questions/12971631/sorting-list-by-an-attribute-that-can-be-none

Since it's not that important to sort, I propose to ignore those cases.