### PR TITLE
Fixed bug with `cached_property` non-Model objects not being traversed

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -358,15 +358,17 @@ def _follow_field_source(model, path: List[str]):
             else:
                 return field
     else:
-        if isinstance(field_or_property, property) or callable(field_or_property):
+        if isinstance(field_or_property, (property, cached_property)) or callable(field_or_property):
             if isinstance(field_or_property, property):
                 target_model = typing.get_type_hints(field_or_property.fget).get('return')
+            elif isinstance(field_or_property, cached_property):
+                target_model = typing.get_type_hints(field_or_property.func).get('return')
             else:
                 target_model = typing.get_type_hints(field_or_property).get('return')
             if not target_model:
                 raise UnableToProceedError(
                     f'could not follow field source through intermediate property "{path[0]}" '
-                    f'on model {model}. please add a type hint on the model\'s property/function '
+                    f'on model {model}. Please add a type hint on the model\'s property/function '
                     f'to enable traversal of the source path "{".".join(path)}".'
                 )
             return _follow_field_source(target_model, path[1:])

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -173,6 +173,24 @@ components:
         field_json:
           type: object
           additionalProperties: {}
+        field_sub_object_calculated:
+          type: integer
+          readOnly: true
+        field_sub_object_nested_calculated:
+          type: integer
+          readOnly: true
+        field_sub_object_model_int:
+          type: integer
+          readOnly: true
+        field_sub_object_cached_calculated:
+          type: integer
+          readOnly: true
+        field_sub_object_cached_nested_calculated:
+          type: integer
+          readOnly: true
+        field_sub_object_cached_model_int:
+          type: integer
+          readOnly: true
         field_int:
           type: integer
         field_float:
@@ -292,6 +310,12 @@ components:
       - field_related_string
       - field_slug
       - field_smallint
+      - field_sub_object_cached_calculated
+      - field_sub_object_cached_model_int
+      - field_sub_object_cached_nested_calculated
+      - field_sub_object_calculated
+      - field_sub_object_model_int
+      - field_sub_object_nested_calculated
       - field_text
       - field_time
       - field_url


### PR DESCRIPTION
Without this patch, paths like source="sub_object.part" were not being traversed to find type annotations for `part` if `sub_object` was a non-Model class defined using `cached_property` instead of `property`.

Tests are added for both the `property` and `cached_property` cases, and some further recursive possibilities. e.g. going back to a Model class.
