### PR TITLE
Fix map_renderers where format is None

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -824,8 +824,9 @@ class AutoSchema(ViewInspector):
     def map_renderers(self, attribute):
         assert attribute in ['media_type', 'format']
         return list(dict.fromkeys([
-            getattr(r, attribute).split(';')[0] for r in self.view.get_renderers()
-            if not isinstance(r, renderers.BrowsableAPIRenderer)
+            getattr(r, attribute).split(';')[0]
+            for r in self.view.get_renderers()
+            if not isinstance(r, renderers.BrowsableAPIRenderer) and getattr(r, attribute)
         ]))
 
     def _get_serializer(self):

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -826,7 +826,7 @@ class AutoSchema(ViewInspector):
         return list(dict.fromkeys([
             getattr(r, attribute).split(';')[0]
             for r in self.view.get_renderers()
-            if not isinstance(r, renderers.BrowsableAPIRenderer) and getattr(r, attribute)
+            if not isinstance(r, renderers.BrowsableAPIRenderer) and getattr(r, attribute, None)
         ]))
 
     def _get_serializer(self):


### PR DESCRIPTION
On `rest_framework.renderers.BaseRenderer` the default for the `format` attribute is `None`. Although it is set to a string in most subclasses, `map_renderer` should handle the case where it is not.