### PR TITLE
add support for all django-filters RangeFilter

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -133,7 +133,8 @@ class DjangoFilterExtension(OpenApiFilterExtension):
             explode = True
             style = 'form'
         elif isinstance(filter_field, (filters.RangeFilter, filters.NumericRangeFilter)):
-            field_names = [f'{field_name}_min', f'{field_name}_max']
+            suffixes = filter_field.field_class.widget.suffixes
+            field_names = [f'{field_name}_{suffixes[0]}', f'{field_name}_{suffixes[1]}']
             explode = None
             style = None
         else:


### PR DESCRIPTION
Attempt to support all django-filters RangeFilters.

existing tests pass, I probably should make tests for some other cases.

I tried it on a project using DateFromToRangeFilter and it works as expected (with date_before and date_after query parameters)