### PR TITLE
Fixed traversing of 'Optional' type annotations

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,6 +2,7 @@ import tempfile
 import uuid
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from typing import Optional
 
 import pytest
 from django import __version__ as DJANGO_VERSION
@@ -47,6 +48,10 @@ class SubObject:
     @property
     def model_instance(self) -> 'AllFields':
         return self._instance
+
+    @property
+    def optional_int(self) -> Optional[int]:
+        return 1
 
 
 class AllFields(models.Model):
@@ -127,6 +132,10 @@ class AllFields(models.Model):
     def sub_object_cached(self) -> SubObject:
         return SubObject(self)
 
+    @property
+    def optional_sub_object(self) -> Optional[SubObject]:
+        return SubObject(self)
+
 
 class AllFieldsSerializer(serializers.ModelSerializer):
     field_decimal_uncoerced = serializers.DecimalField(
@@ -203,6 +212,16 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     field_sub_object_cached_calculated = serializers.ReadOnlyField(source='sub_object_cached.calculated')
     field_sub_object_cached_nested_calculated = serializers.ReadOnlyField(source='sub_object_cached.nested.calculated')
     field_sub_object_cached_model_int = serializers.ReadOnlyField(source='sub_object_cached.model_instance.field_int')
+
+    # typing.Optional
+    field_optional_sub_object_calculated = serializers.ReadOnlyField(
+        source='optional_sub_object.calculated',
+        allow_null=True,
+    )
+    field_sub_object_optional_int = serializers.ReadOnlyField(
+        source='sub_object.optional_int',
+        allow_null=True,
+    )
 
     class Meta:
         fields = '__all__'

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -192,6 +192,14 @@ components:
         field_sub_object_cached_model_int:
           type: integer
           readOnly: true
+        field_optional_sub_object_calculated:
+          type: integer
+          readOnly: true
+          nullable: true
+        field_sub_object_optional_int:
+          type: integer
+          nullable: true
+          readOnly: true
         field_int:
           type: integer
         field_float:
@@ -300,6 +308,7 @@ components:
       - field_model_cached_property_float
       - field_model_property_float
       - field_o2o
+      - field_optional_sub_object_calculated
       - field_posint
       - field_possmallint
       - field_read_only_model_function_basic
@@ -318,6 +327,7 @@ components:
       - field_sub_object_calculated
       - field_sub_object_model_int
       - field_sub_object_nested_calculated
+      - field_sub_object_optional_int
       - field_text
       - field_time
       - field_url


### PR DESCRIPTION
This patch turns `Optional[Foo]` into `Foo` when traversing type annotations, allowing more fields to be automatically detected from type hints.

This change brings up some issues:

1. For an `Optional`, we have the possibility of `None`, and we are throwing that information away here. Given: 
   * the DRF behaviour (attribute errors will result in the field being omitted, unless `allow_null=True` is specified in which case you get `null`), 
   * and the drf-spectacular behaviour (you have to specify `allow_null=True` on the field to get `nullable: true` in the output), 

   ...I think this behaviour is correct if you add `allow_null=True`. It is possibly not correct without that, however, and might require quite a bit of extra work to propagate the "nullability" of a field up the chain somehow.  I think the same issue must already exist for a nullable FK field, there is no infrastructure to propagate the nullability.
2. Since we detect `Optional` by detecting a special case of `Union`, what should we do with the other `Union` possibilities? 

   I have opted here for generating a warning. I think dealing with `Union` fully is very complex. For example, suppose we have a `source="foo_or_bar.baz"`, where `foo_or_bar` is typed as `Union[Foo, Bar]`. If we attempt to traverse this, we have the possibilities that `baz` may not exist on one of `Foo` or `Bar`, or both, or that it exists on both but is differently typed. We then also have the possibility of the next part of the chain also giving `Union` types - attempting to deal with all these would be very complex. Instead I think we should just prompt the user to provide a property/method that handles all this complexity with an explicit type.
