### PR TITLE
DjangoFilters: Add description for enum choices

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -5,8 +5,8 @@ from django.db import models
 from drf_spectacular.drainage import warn
 from drf_spectacular.extensions import OpenApiFilterExtension
 from drf_spectacular.plumbing import (
-    build_array_type, build_basic_type, build_parameter_type, follow_field_source, get_view_model,
-    is_basic_type,
+    build_array_type, build_basic_type, build_choices_description, build_parameter_type, follow_field_source,
+    get_view_model, is_basic_type,
 )
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
@@ -120,6 +120,10 @@ class DjangoFilterExtension(OpenApiFilterExtension):
             description = filter_field.extra['help_text']
         elif filter_field.label is not None:
             description = filter_field.label
+
+        if 'choices' in filter_field.extra:
+            description = (description + '\n') if description else ''
+            description += build_choices_description(filter_field.extra['choices'])
 
         # parameter style variations based on filter base class
         if isinstance(filter_field, filters.BaseCSVFilter):

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -299,6 +299,10 @@ def build_choice_field(field):
         'enum': choices
     }
 
+    description = build_choices_description(field.choices.items())
+    if description:
+        schema['description'] = description
+
     # If We figured out `type` then and only then we should set it. It must be a string.
     # Ref: https://swagger.io/docs/specification/data-models/data-types/#mixed-type
     # It is optional but it can not be null.
@@ -969,3 +973,11 @@ def resolve_type_hint(hint):
         return schema
     else:
         raise UnableToProceedError()
+
+
+def build_choices_description(choices):
+    description = ''
+    for choice in choices:
+        print(choice)
+        description += f'* "{choice[0]}" - {choice[1]}\n'
+    return description

--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -20,7 +20,10 @@ paths:
           enum:
           - A
           - B
-        description: some category description
+        description: |
+          some category description
+          * "A" - aaa
+          * "B" - b
       - in: query
         name: custom_filter
         schema:
@@ -120,7 +123,12 @@ paths:
             - -price
             - in_stock
             - price
-        description: Ordering
+        description: |
+          Ordering
+          * "price" - Price
+          * "-price" - Price (descending)
+          * "in_stock" - in stock
+          * "-in_stock" - in stock (descending)
         explode: false
         style: form
       - in: query


### PR DESCRIPTION
The choices in a ChoiceFilter (enum) can be documented via the description, similar to what's already in place for OrderingFilter.

This will help users, for example in SwaggerUI.

No idea if this is the best way / place to implement this, but it works locally at least.

Before:
![image](https://user-images.githubusercontent.com/4426050/119223579-8facf800-bafa-11eb-9eee-7c4b93101ede.png)


After:
![image](https://user-images.githubusercontent.com/4426050/119223594-9dfb1400-bafa-11eb-84c7-aca9d773f8d0.png)

