### PR TITLE
fix: avoid circular import of/via rest_framework's APIView

### DIFF
--- a/drf_spectacular/extensions.py
+++ b/drf_spectacular/extensions.py
@@ -1,11 +1,11 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING, List, Optional, Type
 
-from rest_framework.views import APIView
-
 from drf_spectacular.plumbing import OpenApiGeneratorExtension
 
 if TYPE_CHECKING:
+    from rest_framework.views import APIView
+
     from drf_spectacular.openapi import AutoSchema
 
 
@@ -97,7 +97,7 @@ class OpenApiViewExtension(OpenApiGeneratorExtension['OpenApiViewExtension']):
             cls.target_class = cls.target_class.cls
 
     @abstractmethod
-    def view_replacement(self) -> Type[APIView]:
+    def view_replacement(self) -> 'Type[APIView]':
         pass  # pragma: no cover
 
 


### PR DESCRIPTION
The typing hints added in 9819424 caused a regression with version
0.17.1, where importing `OpenApiAuthenticationExtension` from
`drf_spectacular.extensions` might cause a circular import error:

> ImportError: Could not import
> 'project.app.authentication.MyAuthentication' for API setting
> 'DEFAULT_AUTHENTICATION_CLASSES'. ImportError: cannot import name
> 'OpenApiAuthenticationExtension' from partially initialized module
> 'drf_spectacular.extensions' (most likely due to a circular import)
> (…/.venv/lib/python3.9/site-packages/drf_spectacular/extensions.py).