### PR TITLE
Fix typo in swagger_ui.js

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.js
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.js
@@ -17,6 +17,6 @@ const ui = SwaggerUIBundle({
   ...swagger_settings
 })
 
-{% if ouath2_config %}
+{% if oauth2_config %}
 ui.initOAuth({{oauth2_config|safe}})
 {% endif %}


### PR DESCRIPTION
Changed `ouath2_config` -> `oauth2_config`

This is in regards to #438 