### PR TITLE
support raw schema on `extend_schema_field`

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -842,11 +842,15 @@ class AutoSchema(ViewInspector):
         try:
             return resolve_type_hint(hint)
         except UnableToProceedError:
-            warn(
-                f'unable to resolve type hint for function "{method.__name__}". Consider '
-                f'using a type hint or @extend_schema_field. Defaulting to string.'
-            )
-            return build_basic_type(OpenApiTypes.STR)
+            if type(hint) is dict:
+                # if raw schema is passed for a field, @extend_schema_field({'type': 'array', 'items': {'ref': '#/components/schemas/MyRecursiveComponent'}})
+                return hint
+            else:
+                warn(
+                    f'unable to resolve type hint for function "{method.__name__}". Consider '
+                    f'using a type hint or @extend_schema_field. Defaulting to string.'
+                )
+                return build_basic_type(OpenApiTypes.STR)
 
     def _get_paginator(self):
         pagination_class = getattr(self.view, 'pagination_class', None)


### PR DESCRIPTION
Raw schema can be passed to `extend_schema_field` decorator in this fashion

```py
@extend_schema_field({
  'type': 'array',
  'items': {
    'ref': '#/components/schemas/MyRecursiveComponent'
    }
  })
```


This change could have been done inside `resolve_type_hint`, but that method name suggests that it handles a different task.