### PR TITLE
Move system check registration to AppConfig

### DIFF
--- a/drf_spectacular/__init__.py
+++ b/drf_spectacular/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.18.1'
 
-import drf_spectacular.checks  # noqa: F401
+default_app_config = 'drf_spectacular.apps.SpectacularConfig'

--- a/drf_spectacular/apps.py
+++ b/drf_spectacular/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class SpectacularConfig(AppConfig):
+    name = 'drf_spectacular'
+    verbose_name = "drf-spectacular"
+
+    def ready(self):
+        import drf_spectacular.checks  # noqa: F401


### PR DESCRIPTION
Registering the system check in the `__init__.py` file has the unfortunate
side effect of registering the check even when the app is not installed.
This can be problematic as DRF settings may also be missing and
`DEFAULT_SCHEMA_CLASS` may not be setup correctly. This will result in
erroneous failed system checks that cannot be solved easily.

We ran into this issue while running custom commands that ran with
Django settings that didn't have `drf-spectacular` or `rest_framework`
in `INSTALLED_APPS`.

The exact errors we saw were:
```
SystemCheckError: System check identified some issues:

ERRORS:
?: (drf_spectacular.E001) Schema generation threw exception "Incompatible AutoSchema used on View <class 'account.views.UserCreateView'>. Is DRF's DEFAULT_SCHEMA_CLASS pointing to "drf_spectacular.openapi.AutoSchema" or any other drf-spectacular compatible AutoSchema?"

WARNINGS:
?: (drf_spectacular.W001) @extend_schema_view argument "partial_update" was not found on view ApiCredentialViewSet. method override for "partial_update" will be ignored.
```