### PR TITLE
Extend enum type hint support to more Enum subclasses

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -969,7 +969,7 @@ def resolve_type_hint(hint):
         if all(type(args[0]) is type(choice) for choice in args):
             schema.update(build_basic_type(type(args[0])))
         return schema
-    elif inspect.isclass(hint) and issubclass(hint, Choices):
+    elif inspect.isclass(hint) and issubclass(hint, Enum):
         return {
             'enum': [item.value for item in hint],
             **build_basic_type([t for t in hint.__mro__ if is_basic_type(t)][0])

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -4,6 +4,7 @@ import re
 import sys
 import typing
 from datetime import datetime
+from enum import Enum
 
 import pytest
 from django import __version__ as DJANGO_VERSION
@@ -90,6 +91,11 @@ class NamedTupleB(typing.NamedTuple):
     b: str
 
 
+class LanguageEnum(str, Enum):
+    EN = 'en'
+    DE = 'de'
+
+
 TYPE_HINT_TEST_PARAMS = [
     (
         typing.Optional[int],
@@ -135,6 +141,11 @@ TYPE_HINT_TEST_PARAMS = [
         {'oneOf': [{'type': 'string'}, {'type': 'integer'}], 'nullable': True}
     )
 ]
+
+TYPE_HINT_TEST_PARAMS.append((
+    LanguageEnum,
+    {'enum': ['en', 'de'], 'type': 'string'}
+))
 
 if DJANGO_VERSION > '3':
     from django.db.models.enums import TextChoices  # only available in Django>3

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -37,6 +37,10 @@ class LanguageEnum(Enum):
     EN = 'en'
 
 
+class LanguageStrEnum(str, Enum):
+    EN = 'en'
+
+
 class LanguageChoices(TextChoices):
     EN = 'en'
 
@@ -174,7 +178,7 @@ def test_enum_resolvable_collision_with_patched_and_request_splits():
 
 
 def test_enum_override_variations(no_warnings):
-    enum_override_variations = ['language_list', 'LanguageEnum']
+    enum_override_variations = ['language_list', 'LanguageEnum', 'LanguageStrEnum']
     if DJANGO_VERSION > '3':
         enum_override_variations += ['LanguageChoices', 'LanguageChoices.choices']
 


### PR DESCRIPTION
Add support for all subclasses of Enum and a supported basic type. This
can be useful in cases where an enum subclass of `Choices` does not make
semantic sense.

We ran into this while fixing system checks on our codebase. There were instances
of enums defined as subclasses of `(str, Enum)` that work perfectly fine (we're also
using `django-enumfields`), but threw warnings. While we could use `TextChoices`,
it doesn't make semantic sense as they are "core" enums.

I'm not sure if there's a mypy issue with these types of enums, but DRF doesn't seem
to mind.
