### PR TITLE
Fix type hint support for functools cached_property wrapped funcs

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -19,6 +19,14 @@ from rest_framework.test import APIClient
 from drf_spectacular.generators import SchemaGenerator
 from tests import assert_schema
 
+try:
+    functools_cached_property = functools.cached_property  # type: ignore
+except AttributeError:
+    # functools.cached_property is only available in Python 3.8+.
+    # We re-use Django's cached_property when it's not avaiable to
+    # keep tests unified across Python versions.
+    functools_cached_property = cached_property
+
 fs = FileSystemStorage(location=tempfile.gettempdir())
 
 
@@ -113,7 +121,7 @@ class AllFields(models.Model):
     def field_model_cached_property_float(self) -> float:
         return 1.337
 
-    @functools.cached_property  # type: ignore
+    @functools_cached_property
     def field_model_py_cached_property_float(self) -> float:
         return 1.337
 
@@ -139,7 +147,7 @@ class AllFields(models.Model):
     def sub_object_cached(self) -> SubObject:
         return SubObject(self)
 
-    @functools.cached_property  # type: ignore
+    @functools_cached_property
     def sub_object_py_cached(self) -> SubObject:
         return SubObject(self)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+import functools
 import tempfile
 import uuid
 from datetime import date, datetime, timedelta
@@ -112,6 +113,10 @@ class AllFields(models.Model):
     def field_model_cached_property_float(self) -> float:
         return 1.337
 
+    @functools.cached_property  # type: ignore
+    def field_model_py_cached_property_float(self) -> float:
+        return 1.337
+
     @property
     def field_list(self):
         return [1.1, 2.2, 3.3]
@@ -132,6 +137,10 @@ class AllFields(models.Model):
 
     @cached_property
     def sub_object_cached(self) -> SubObject:
+        return SubObject(self)
+
+    @functools.cached_property  # type: ignore
+    def sub_object_py_cached(self) -> SubObject:
         return SubObject(self)
 
     @property
@@ -199,6 +208,8 @@ class AllFieldsSerializer(serializers.ModelSerializer):
 
     field_model_cached_property_float = serializers.ReadOnlyField()
 
+    field_model_py_cached_property_float = serializers.ReadOnlyField()
+
     field_dict_int = serializers.DictField(
         child=serializers.IntegerField(),
         source='field_json',
@@ -216,6 +227,14 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     field_sub_object_cached_calculated = serializers.ReadOnlyField(source='sub_object_cached.calculated')
     field_sub_object_cached_nested_calculated = serializers.ReadOnlyField(source='sub_object_cached.nested.calculated')
     field_sub_object_cached_model_int = serializers.ReadOnlyField(source='sub_object_cached.model_instance.field_int')
+
+    field_sub_object_py_cached_calculated = serializers.ReadOnlyField(source='sub_object_py_cached.calculated')
+    field_sub_object_py_cached_nested_calculated = serializers.ReadOnlyField(
+        source='sub_object_py_cached.nested.calculated',
+    )
+    field_sub_object_py_cached_model_int = serializers.ReadOnlyField(
+        source='sub_object_py_cached.model_instance.field_int',
+    )
 
     # typing.Optional
     field_optional_sub_object_calculated = serializers.ReadOnlyField(

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -167,6 +167,10 @@ components:
           type: number
           format: float
           readOnly: true
+        field_model_py_cached_property_float:
+          type: number
+          format: float
+          readOnly: true
         field_dict_int:
           type: object
           additionalProperties:
@@ -190,6 +194,15 @@ components:
           type: integer
           readOnly: true
         field_sub_object_cached_model_int:
+          type: integer
+          readOnly: true
+        field_sub_object_py_cached_calculated:
+          type: integer
+          readOnly: true
+        field_sub_object_py_cached_nested_calculated:
+          type: integer
+          readOnly: true
+        field_sub_object_py_cached_model_int:
           type: integer
           readOnly: true
         field_optional_sub_object_calculated:
@@ -303,6 +316,7 @@ components:
       - field_method_object
       - field_model_cached_property_float
       - field_model_property_float
+      - field_model_py_cached_property_float
       - field_o2o
       - field_optional_sub_object_calculated
       - field_posint
@@ -324,6 +338,9 @@ components:
       - field_sub_object_model_int
       - field_sub_object_nested_calculated
       - field_sub_object_optional_int
+      - field_sub_object_py_cached_calculated
+      - field_sub_object_py_cached_model_int
+      - field_sub_object_py_cached_nested_calculated
       - field_text
       - field_time
       - field_url


### PR DESCRIPTION
functools added a `cached_property` wrapper in Python 3.8. Support type
hinting for properties wrapped in both Django's `cached_property` and
functool's `cached_property`.

This came up while fixing system check warnings. I couldn't figure out why
the "property" was being reported as "magic" until I checked the type
hinting detection source code.
