### PR TITLE
Fix handling of AUTH_HEADER_TYPES in SimpleJWTScheme.

### DIFF
--- a/drf_spectacular/contrib/rest_framework_simplejwt.py
+++ b/drf_spectacular/contrib/rest_framework_simplejwt.py
@@ -74,7 +74,7 @@ class SimpleJWTScheme(OpenApiAuthenticationExtension):
 
         if header_name.startswith('HTTP_'):
             header_name = header_name[5:]
-        header_name = header_name.replace('_', '-').capitalize()
+        header_name = header_name.replace('_', ' ').title().replace(' ', '-')
         return {
             'type': 'apiKey',
             'in': 'header',

--- a/drf_spectacular/contrib/rest_framework_simplejwt.py
+++ b/drf_spectacular/contrib/rest_framework_simplejwt.py
@@ -61,29 +61,26 @@ class SimpleJWTScheme(OpenApiAuthenticationExtension):
                 f'OpenAPI3 can only have one "bearerFormat". JWT Settings specify '
                 f'{api_settings.AUTH_HEADER_TYPES}. Using the first one.'
             )
-        header_name = getattr(api_settings, 'AUTH_HEADER_NAME', 'HTTP_AUTHORIZATION')
 
-        if (
-            api_settings.AUTH_HEADER_TYPES[0] == 'Bearer'
-            and header_name == 'HTTP_AUTHORIZATION'
-        ):
+        header_name = getattr(api_settings, 'AUTH_HEADER_NAME', 'HTTP_AUTHORIZATION')
+        header_type = api_settings.AUTH_HEADER_TYPES[0]
+
+        if header_name == 'HTTP_AUTHORIZATION':
             return {
                 'type': 'http',
                 'scheme': 'bearer',
-                'bearerFormat': "JWT",
+                'bearerFormat': header_type,
             }
-        else:
-            if header_name.startswith('HTTP_'):
-                header_name = header_name[5:]
-            header_name = header_name.replace('_', '-').capitalize()
-            return {
-                'type': 'apiKey',
-                'in': 'header',
-                'name': header_name,
-                'description': _(
-                    'Token-based authentication with required prefix "%s"'
-                ) % api_settings.AUTH_HEADER_TYPES[0]
-            }
+
+        if header_name.startswith('HTTP_'):
+            header_name = header_name[5:]
+        header_name = header_name.replace('_', '-').capitalize()
+        return {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': header_name,
+            'description': _('Token-based authentication with required prefix "%s"') % header_type,
+        }
 
 
 class SimpleJWTTokenUserScheme(SimpleJWTScheme):

--- a/tests/contrib/test_drf_jwt.py
+++ b/tests/contrib/test_drf_jwt.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.urls import path
 from rest_framework import mixins, routers, serializers, viewsets
@@ -35,3 +37,17 @@ def test_drf_jwt(no_warnings):
     schema = generate_schema(None, patterns=urlpatterns)
 
     assert_schema(schema, 'tests/contrib/test_drf_jwt.yml')
+
+
+@pytest.mark.contrib('rest_framework_jwt')
+@pytest.mark.parametrize('prefix', ['Bearer', 'JWT'])
+def test_drf_jwt_header_prefix(no_warnings, prefix):
+    with mock.patch('rest_framework_jwt.settings.api_settings.JWT_AUTH_HEADER_PREFIX', prefix):
+        schema = generate_schema('/x', XViewset)
+        assert schema['components']['securitySchemes'] == {
+            'jwtAuth': {
+                'type': 'http',
+                'scheme': 'bearer',
+                'bearerFormat': prefix,
+            }
+        }

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -51,32 +51,34 @@ def test_simplejwt(no_warnings, view):
 
 
 @pytest.mark.contrib('rest_framework_simplejwt')
-@mock.patch('rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_TYPES', ('JWT',))
-def test_simplejwt_non_bearer_keyword(no_warnings):
-    schema = generate_schema('/x', XViewset)
-    assert schema['components']['securitySchemes'] == {
-        'jwtAuth': {
-            'type': 'apiKey',
-            'in': 'header',
-            'name': 'Authorization',
-            'description': 'Token-based authentication with required prefix "JWT"'
+@pytest.mark.parametrize('prefix', ['Bearer', 'JWT'])
+def test_simplejwt_header_prefix(no_warnings, prefix):
+    with mock.patch('rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_TYPES', [prefix]):
+        schema = generate_schema('/x', XViewset)
+        assert schema['components']['securitySchemes'] == {
+            'jwtAuth': {
+                'type': 'http',
+                'scheme': 'bearer',
+                'bearerFormat': prefix,
+            }
         }
-    }
 
 
 @pytest.mark.contrib('rest_framework_simplejwt')
+@pytest.mark.parametrize('prefix', ['Bearer', 'JWT'])
 @mock.patch(
     'rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_NAME',
     'HTTP_X_TOKEN',
     create=True,
 )
-def test_simplejwt_non_std_header_name(no_warnings):
-    schema = generate_schema('/x', XViewset)
-    assert schema['components']['securitySchemes'] == {
-        'jwtAuth': {
-            'type': 'apiKey',
-            'in': 'header',
-            'name': 'X-token',
-            'description': 'Token-based authentication with required prefix "Bearer"'
+def test_simplejwt_non_std_header_name(no_warnings, prefix):
+    with mock.patch('rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_TYPES', [prefix]):
+        schema = generate_schema('/x', XViewset)
+        assert schema['components']['securitySchemes'] == {
+            'jwtAuth': {
+                'type': 'apiKey',
+                'in': 'header',
+                'name': 'X-token',
+                'description': f'Token-based authentication with required prefix "{prefix}"',
+            }
         }
-    }

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -78,7 +78,7 @@ def test_simplejwt_non_std_header_name(no_warnings, prefix):
             'jwtAuth': {
                 'type': 'apiKey',
                 'in': 'header',
-                'name': 'X-token',
+                'name': 'X-Token',
                 'description': f'Token-based authentication with required prefix "{prefix}"',
             }
         }

--- a/tests/contrib/test_simplejwt.yml
+++ b/tests/contrib/test_simplejwt.yml
@@ -164,4 +164,4 @@ components:
     jwtAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
+      bearerFormat: Bearer


### PR DESCRIPTION
For `SimpleJWTScheme`, when using the `Authorization` header, the schema output should use the `type: http` and `scheme: bearer` values with `bearerFormat` set to the first value of `AUTH_HEADER_TYPES`.

The `drf_spectacular/contrib/rest_framework_jwt.JWTScheme` extension takes this approach.

Currently if the first value of `AUTH_HEADER_TYPES` is `Bearer` the value of `bearerFormat` is set to `JWT`, but if the value is `JWT` then `type: apiKey` is used instead. This seems rather inconsistent and is purely based on the order of items in `AUTH_HEADER_TYPES` which has no bearing on the whether the prefix is acceptable. The first value is only used in preference by `djangorestframework-simplejwt` for a value to use in the `WWW-Authenticate` header.

While I was in the area, I added some extra test coverage and improved the header name generated in the schema by `SimpleJWTScheme`.

(Just thought I'd mention that I've already read into #467 and #474, but think that there ought to be a change here.) 

----

As an aside, if we have `AUTH_HEADER_TYPES = ['Bearer', 'JWT']`, it would seem reasonable to generate something like the following:

```yaml
  securitySchemes:
    jwtAuth1:
      type: http
      scheme: bearer
      bearerFormat: Bearer
    jwtAuth2:
      type: http
      scheme: bearer
      bearerFormat: JWT
```

Both schemes are perfectly valid as `djangorestframework-simplejwt` will accept either prefix when validating the header. Alas, `OpenApiAuthenticationExtension.get_security_definition()` only allows for a single scheme to be returned. I'm not sure whether this is something to consider in the future as a someday/maybe?