### PR TITLE
Handle 'lookup_field' containing relationships for path parameters

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -16,11 +16,13 @@ from typing import DefaultDict, Generic, List, Optional, Type, TypeVar, Union
 import inflection
 import uritemplate
 from django.apps import apps
+from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields.related_descriptors import (
     ForwardManyToOneDescriptor, ManyToManyDescriptor, ReverseManyToOneDescriptor,
     ReverseOneToOneDescriptor,
 )
 from django.db.models.fields.reverse_related import ForeignObjectRel
+from django.db.models.sql.query import Query
 from django.urls.resolvers import (  # type: ignore
     _PATH_PARAMETER_COMPONENT_RE, RegexPattern, Resolver404, RoutePattern, URLPattern, URLResolver,
     get_resolver,
@@ -458,6 +460,17 @@ def follow_field_source(model, path, emit_warnings=True):
     def dummy_property(obj) -> str:
         pass  # pragma: no cover
     return dummy_property
+
+
+def follow_model_field_lookup(model, lookup):
+    """
+    Follow a model lookup `foreignkey__foreignkey__field` in the same
+    way that Django QuerySet.filter() does, returning the final models.Field.
+    """
+    query = Query(model)
+    lookup_splitted = lookup.split(LOOKUP_SEP)
+    _, field, _, _ = query.names_to_path(lookup_splitted, query.get_meta())
+    return field
 
 
 def alpha_operation_sorter(endpoint):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1459,6 +1459,127 @@ def test_path_param_from_related_model_pk_without_primary_key_true(no_warnings, 
     assert '/x/{related_field}/{id}/' in schema['paths']
 
 
+def test_path_parameter_with_relationships(no_warnings):
+    class PathParamParent(models.Model):
+        pass
+
+    class PathParamChild(models.Model):
+        parent = models.ForeignKey(PathParamParent, on_delete=models.CASCADE)
+
+    class PathParamGrandChild(models.Model):
+        parent = models.ForeignKey(PathParamChild, on_delete=models.CASCADE)
+
+    class PathParamChildSerializer(serializers.ModelSerializer):
+        class Meta:
+            fields = '__all__'
+            model = PathParamChild
+
+    class XViewset1(viewsets.ModelViewSet):
+        serializer_class = PathParamChildSerializer
+        queryset = PathParamChild.objects.none()
+        lookup_field = 'id'
+
+    class XViewset2(viewsets.ModelViewSet):
+        serializer_class = PathParamChildSerializer
+        queryset = PathParamChild.objects.none()
+        lookup_field = 'parent'
+
+    class XViewset3(viewsets.ModelViewSet):
+        serializer_class = PathParamChildSerializer
+        queryset = PathParamChild.objects.none()
+        lookup_field = 'parent__id'  # Functionally the same as above
+
+    class PathParamGrandChildSerializer(serializers.ModelSerializer):
+        class Meta:
+            fields = '__all__'
+            model = PathParamGrandChild
+
+    class XViewset4(viewsets.ModelViewSet):
+        serializer_class = PathParamGrandChildSerializer
+        queryset = PathParamGrandChild.objects.none()
+        lookup_field = 'parent__parent'
+
+    class XViewset5(viewsets.ModelViewSet):
+        serializer_class = PathParamGrandChildSerializer
+        queryset = PathParamGrandChild.objects.none()
+        lookup_field = 'parent__parent__id'
+
+    router = routers.SimpleRouter()
+    router.register('child_by_id', XViewset1)
+    router.register('child_by_parent_id', XViewset2)
+    router.register('child_by_parent_id_alt', XViewset3)
+    router.register('grand_child_by_grand_parent_id', XViewset4)
+    router.register('grand_child_by_grand_parent_id_alt', XViewset5)
+
+    schema = generate_schema(None, patterns=router.urls)
+
+    # Basic cases:
+    assert schema['paths']['/child_by_id/{id}/']['get']['parameters'][0] == {
+        'description': 'A unique integer value identifying this path param child.',
+        'in': 'path',
+        'name': 'id',
+        'schema': {'type': 'integer'},
+        'required': True
+    }
+    assert schema['paths']['/child_by_parent_id/{parent}/']['get']['parameters'][0] == {
+        'in': 'path',
+        'name': 'parent',
+        'schema': {'type': 'integer'},
+        'required': True
+    }
+
+    # Can we traverse relationships?
+    assert schema['paths']['/grand_child_by_grand_parent_id/{parent__parent}/']['get']['parameters'][0] == {
+        'in': 'path',
+        'name': 'parent__parent',
+        'schema': {'type': 'integer'},
+        'required': True
+    }
+
+    # Explicit `__id` handling:
+    assert schema['paths']['/grand_child_by_grand_parent_id_alt/{parent__parent__id}/']['get']['parameters'][0] == {
+        'description': 'A unique integer value identifying this path param grand child.',
+        'in': 'path',
+        'name': 'parent__parent__id',
+        'schema': {'type': 'integer'},
+        'required': True
+    }
+    assert schema['paths']['/child_by_parent_id_alt/{parent__id}/']['get']['parameters'][0] == {
+        'description': 'A unique integer value identifying this path param child.',
+        'in': 'path',
+        'name': 'parent__id',
+        'schema': {'type': 'integer'},
+        'required': True
+    }
+
+
+def test_path_parameter_with_lookups(no_warnings):
+    class JournalEntry(models.Model):
+        recorded_at = models.DateTimeField()
+
+    class JournalEntrySerializer(serializers.ModelSerializer):
+        class Meta:
+            fields = '__all__'
+            model = JournalEntry
+
+    class JournalEntryViewset(viewsets.ModelViewSet):
+        serializer_class = JournalEntrySerializer
+        queryset = JournalEntry.objects.none()
+        lookup_field = 'recorded_at__date'
+
+    router = routers.SimpleRouter()
+    router.register('journal', JournalEntryViewset)
+
+    schema = generate_schema(None, patterns=router.urls)
+
+    assert schema['paths']['/journal/{recorded_at__date}/']['get']['parameters'][0] == {
+        'in': 'path',
+        'name': 'recorded_at__date',
+        'required': True,
+        'schema': {'format': 'date-time', 'type': 'string'},
+    }
+
+
 @pytest.mark.contrib('psycopg2')
 def test_multiple_choice_enum(no_warnings):
     from django.contrib.postgres.fields import ArrayField

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -374,3 +374,15 @@ def test_warning_read_only_field_on_non_model_serializer(capsys):
     generate_schema('x', XViewSet)
     stderr = capsys.readouterr().err
     assert 'Could not derive type for ReadOnlyField "field"' in stderr
+
+
+def test_warning_missing_lookup_field_on_model_serializer(capsys):
+    class XViewSet(viewsets.ModelViewSet):
+        serializer_class = SimpleSerializer
+        queryset = SimpleModel.objects.all()
+        lookup_field = 'non_existent_field'
+
+    generate_schema('x', XViewSet)
+    stderr = capsys.readouterr().err
+    assert ('could not derive type of path parameter "non_existent_field" because model '
+            '"tests.models.SimpleModel" contained no such field.') in stderr


### PR DESCRIPTION
This PR fixes introspection cases like:
```python

class MyViewSet(GenericViewSet):
    queryset = MyModel.objects.all()
    lookup_field = 'parent__id'
```
and similar, which previously would just default to `string` type with a warning.

It also fixes cases where a lookup type like `contains` or `iexact` was used. These are valid in DRF as can be seen from the tests - https://github.com/encode/django-rest-framework/blob/9ce541e90990307e06da1b7f5a2576406366a5e5/tests/test_routers.py#L41

## Strategy

The strategy I used was to trace how these are handled by DRF, which is ultimately just a call to `QuerySet.filter` - see https://github.com/encode/django-rest-framework/blob/9ce541e90990307e06da1b7f5a2576406366a5e5/rest_framework/generics.py#L95

Eventually these get parsed by [Query.names_to_path](https://github.com/django/django/blob/46c8df640cfed5dd525ac1bcf5ad7e57b7ff2571/django/db/models/sql/query.py#L1460). So I have just wrapped up that logic with a helper function. That `Query` class is an undocumented internal in Django. However, I think this approach is going to be more robust than attempting to duplicate that logic ourselves. Any breakage in this internal API should be easy to spot with good tests (that I have added).

In terms of output, I've found that both `lookup_field = 'fkrelation'` and `lookup_field = 'fkrelation__id'` will produce correct introspection of types, but the latter will also give you a good description, due to a difference in how the lookup terminates. It would be nice if we automatically got the good description for both cases, but after looking at the output from `names_to_path`, I'm not sure it is worth the additional complexity and fragility it might produce.

Tests are added for the new cases handled, and a regression test for the warning in case of a missing field. There are still some cases possibly not handled, especially if you are using `QuerySet.annotate` and do `lookup_field` on the added field.

## Limitations

- There are bugs (as there were before) for any cases where `lookup_url_kwarg` != `lookup_field`, noted in the comment below.
- If you use a Django query lookup that changes the type of the parameter, then you will get incorrect introspection with no warning. So:
  - if you have a `recorded_at` timestamp field, and use `lookup_field = 'recorded_at__year'` (which is probably kind of unlikely for a API lookup since it won't be unique), then with this patch it will act as if you specified just `recorded_at` and assume a date-formatted string, instead of an integer.
  - for many other cases, like `iexact`, which don't change the type, there will be no problem.
