### PR TITLE
fix: get param's regex pattern from part path

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -38,7 +38,7 @@ from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import (
     DJANGO_PATH_CONVERTER_MAPPING, OPENAPI_TYPE_MAPPING, PYTHON_TYPE_MAPPING, OpenApiTypes,
 )
-from drf_spectacular.utils import OpenApiParameter, get_value_from_brackets
+from drf_spectacular.utils import OpenApiParameter
 
 try:
     from django.db.models.enums import Choices  # only available in Django>3
@@ -665,7 +665,10 @@ def resolve_regex_path_parameter(path_regex, variable, available_formats):
     TODO also try to handle regular grouped regex parameters
     """
     for match in _PATH_PARAMETER_COMPONENT_RE.finditer(path_regex):
-        converter, parameter = match.group('converter'), match.group('parameter')
+        converter, param = match.group('converter'), match.group('parameter')
+        enum_values = None
+        parameter = param
+
         if api_settings.SCHEMA_COERCE_PATH_PK and parameter == 'pk':
             parameter = 'id'
 
@@ -673,27 +676,24 @@ def resolve_regex_path_parameter(path_regex, variable, available_formats):
             continue
 
         if not converter:
-            index = match.start() - 3
-            if index < 0:
+            if param == 'pk':
                 return None
-            part_path_regex = path_regex[index:]
-            if part_path_regex.startswith("(?P"):
-                raw_pattern = get_value_from_brackets(part_path_regex)
-                if raw_pattern:
-                    param_pattern = '?P<%s>' % parameter
-                    if len(param_pattern) < len(raw_pattern):
-                        pattern = raw_pattern[len(param_pattern):]
-                        return build_parameter_type(
-                            name=parameter,
-                            schema={
-                                'type': 'string',
-                                'pattern': pattern
-                            },
-                            location=OpenApiParameter.PATH,
-                        )
+            for name, regex in analyze_named_regex_pattern(path_regex).items():
+                if name == param:
+                    if regex == '':
+                        return None
+                    return build_parameter_type(
+                        name=parameter,
+                        schema={
+                            'type': 'string',
+                            'pattern': regex
+                        },
+                        location=OpenApiParameter.PATH,
+                        enum=enum_values,
+                    )
+            return None
 
-        enum_values = None
-        if converter and converter.startswith('drf_format_suffix_'):
+        if converter.startswith('drf_format_suffix_'):
             explicit_formats = converter[len('drf_format_suffix_'):].split('_')
             enum_values = [
                 f'.{suffix}' for suffix in explicit_formats if suffix in available_formats

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -485,3 +485,28 @@ def inline_serializer(name: str, fields: Dict[str, Field], **kwargs) -> Serializ
     """
     serializer_class = type(name, (Serializer,), fields)
     return serializer_class(**kwargs)
+
+
+def get_value_from_brackets(value, start_bracket_symbol="(", end_bracket_symbol=")"):
+    start_bracket_index = value.find(start_bracket_symbol)
+    start_bracket_count = 0 if start_bracket_index == -1 else 1
+    end_bracket_count = 0
+    index = start_bracket_index
+    while index != -1 and start_bracket_count != end_bracket_count:
+        index += 1
+        start_index = value.find(start_bracket_symbol, index)
+        end_index = value.find(end_bracket_symbol, index)
+        if start_index == -1 and end_index == -1:
+            index = -1
+            break
+        if start_index != -1 and end_index > start_index or end_index == -1:
+            start_bracket_count += 1
+            index = start_index
+            continue
+
+        if end_index != -1 and start_index > end_index or start_index == -1:
+            end_bracket_count += 1
+            index = end_index
+
+    if index != -1:
+        return value[start_bracket_index+1:index]

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -485,27 +485,3 @@ def inline_serializer(name: str, fields: Dict[str, Field], **kwargs) -> Serializ
     """
     serializer_class = type(name, (Serializer,), fields)
     return serializer_class(**kwargs)
-
-
-def get_value_from_brackets(value, start_bracket_symbol="(", end_bracket_symbol=")"):
-    start_bracket_index = value.find(start_bracket_symbol)
-    start_bracket_count = 0 if start_bracket_index == -1 else 1
-    end_bracket_count = 0
-    index = start_bracket_index
-    while index != -1 and start_bracket_count != end_bracket_count:
-        index += 1
-        start_index = value.find(start_bracket_symbol, index)
-        end_index = value.find(end_bracket_symbol, index)
-        if start_index == -1 and end_index == -1:
-            index = -1
-            break
-        if start_index != -1 and end_index > start_index or end_index == -1:
-            start_bracket_count += 1
-            index = start_index
-            continue
-
-        if end_index != -1 and start_index > end_index or start_index == -1:
-            end_bracket_count += 1
-            index = end_index
-    if index != -1:
-        return value[start_bracket_index + 1:index]

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -507,6 +507,5 @@ def get_value_from_brackets(value, start_bracket_symbol="(", end_bracket_symbol=
         if end_index != -1 and start_index > end_index or start_index == -1:
             end_bracket_count += 1
             index = end_index
-
     if index != -1:
-        return value[start_bracket_index+1:index]
+        return value[start_bracket_index + 1:index]

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -545,6 +545,29 @@ def test_regex_path_parameter_discovery(no_warnings):
     assert parameter['schema']['type'] == 'integer'
 
 
+def test_regex_path_parameter_discovery_pattern(no_warnings):
+    @extend_schema(responses=OpenApiTypes.FLOAT)
+    @api_view(['GET'])
+    def pi(request, foo):
+        pass  # pragma: no cover
+
+    urlpatterns = [re_path(r'^/pi/(?P<precision>\d+)', pi)]
+    schema = generate_schema(None, patterns=urlpatterns)
+    parameter = schema['paths']['/pi/{precision}']['get']['parameters'][0]
+    assert parameter['name'] == 'precision'
+    assert parameter['in'] == 'path'
+    assert parameter['schema']['type'] == 'string'
+    assert parameter['schema']['pattern'] == '\\d+'
+
+    urlpatterns = [re_path(r'^/pi/(?P<precision>(\d+)-[\w|\.]+(failed|success))', pi)]
+    schema = generate_schema(None, patterns=urlpatterns)
+    parameter = schema['paths']['/pi/{precision}']['get']['parameters'][0]
+    assert parameter['name'] == 'precision'
+    assert parameter['in'] == 'path'
+    assert parameter['schema']['type'] == 'string'
+    assert parameter['schema']['pattern'] == '(\\d+)-[\\w|\\.]+(failed|success)'
+
+
 def test_lib_serializer_naming_collision_resolution(no_warnings):
     """ parity test in tests.test_warnings.test_serializer_name_reuse """
     def x_lib1():

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -87,7 +87,7 @@ def test_path_param_not_in_model(capsys):
         serializer_class = SimpleSerializer
         queryset = SimpleModel.objects.none()
 
-        @action(detail=True, url_path='meta/(?P<ephemeral>[^/.]+)', methods=['POST'])
+        @action(detail=True, url_path='meta/(?P<ephemeral>)', methods=['POST'])
         def meta_param(self, request, ephemeral, pk):
             pass  # pragma: no cover
 


### PR DESCRIPTION
```
urlpatterns = [
    url('^data/(?P<code>[a-zA-Z0-9_\\-]+)/(?P<version>[0-9.]+)', get_data)
]
```

I got warning log:
`could not derive type of path parameter "code" because because it is untyped and obtaining queryset from the viewset failed. Consider adding a type to the path (e.g. <int:code>) or annotating the parameter type with @extend_schema. Defaulting to "string`
