### PR TITLE
Use SESSION_COOKIE_NAME in SessionScheme.

### DIFF
--- a/drf_spectacular/authentication.py
+++ b/drf_spectacular/authentication.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
@@ -12,7 +13,7 @@ class SessionScheme(OpenApiAuthenticationExtension):
         return {
             'type': 'apiKey',
             'in': 'cookie',
-            'name': 'Session',
+            'name': settings.SESSION_COOKIE_NAME,
         }
 
 

--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -241,4 +241,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/contrib/test_djangorestframework_camel_case.yml
+++ b/tests/contrib/test_djangorestframework_camel_case.yml
@@ -58,4 +58,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/contrib/test_rest_auth.yml
+++ b/tests/contrib/test_rest_auth.yml
@@ -504,4 +504,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/contrib/test_rest_auth_token.yml
+++ b/tests/contrib/test_rest_auth_token.yml
@@ -582,4 +582,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/contrib/test_rest_polymorphic.yml
+++ b/tests/contrib/test_rest_polymorphic.yml
@@ -268,4 +268,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -196,4 +196,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -424,4 +424,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_extend_schema_view.yml
+++ b/tests/test_extend_schema_view.yml
@@ -261,4 +261,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -372,4 +372,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_i18n.yml
+++ b/tests/test_i18n.yml
@@ -141,4 +141,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_polymorphic.yml
+++ b/tests/test_polymorphic.yml
@@ -155,4 +155,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_postprocessing.yml
+++ b/tests/test_postprocessing.yml
@@ -88,4 +88,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_recursion.yml
+++ b/tests/test_recursion.yml
@@ -58,4 +58,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_split_request_false.yml
+++ b/tests/test_split_request_false.yml
@@ -113,4 +113,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_split_request_true.yml
+++ b/tests/test_split_request_true.yml
@@ -124,4 +124,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_versioning_accept_v1.yml
+++ b/tests/test_versioning_accept_v1.yml
@@ -62,4 +62,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_versioning_accept_v2.yml
+++ b/tests/test_versioning_accept_v2.yml
@@ -63,4 +63,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_versioning_v1.yml
+++ b/tests/test_versioning_v1.yml
@@ -62,4 +62,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid

--- a/tests/test_versioning_v2.yml
+++ b/tests/test_versioning_v2.yml
@@ -63,4 +63,4 @@ components:
     cookieAuth:
       type: apiKey
       in: cookie
-      name: Session
+      name: sessionid


### PR DESCRIPTION
For context, I'm currently attempting to convert a couple of reasonably large APIs from `drf-yasg` to `drf-spectacular`.

One of the things we have is a custom middleware injected during testing to validate requests and responses against the schema.

To do this, I'm using [`openapi-core`](https://pypi.org/project/openapi-core) which works quite well. (Previously, for OpenAPI 2.0, we were using [`flex`](https://pypi.org/project/flex/).)

For testing purposes, [`.force_login()`](https://docs.djangoproject.com/en/3.2/topics/testing/tools/#django.test.Client.force_login) is used and so `SessionAuthentication` is also injected.

This causes the validation to fail because `SessionScheme` is using a hardcoded value of `'Session'`. Switching this over to `SESSION_COOKIE_NAME` makes this approach work flawlessly. According to the [specification](https://spec.openapis.org/oas/v3.0.3#fixed-fields-22), `name` should be the name of the cookie parameter, so it seems this would be more correct.