### PR TITLE
Add extension for TokenVerifySerializer.

### DIFF
--- a/drf_spectacular/contrib/rest_framework_simplejwt.py
+++ b/drf_spectacular/contrib/rest_framework_simplejwt.py
@@ -49,6 +49,16 @@ class TokenRefreshSerializerExtension(OpenApiSerializerExtension):
         return auto_schema._map_serializer(Fixed, direction)
 
 
+class TokenVerifySerializerExtension(OpenApiSerializerExtension):
+    target_class = 'rest_framework_simplejwt.serializers.TokenVerifySerializer'
+
+    def map_serializer(self, auto_schema, direction):
+        Fixed = inline_serializer('Fixed', fields={
+            'token': serializers.CharField(write_only=True),
+        })
+        return auto_schema._map_serializer(Fixed, direction)
+
+
 class SimpleJWTScheme(OpenApiAuthenticationExtension):
     target_class = 'rest_framework_simplejwt.authentication.JWTAuthentication'
     name = 'jwtAuth'

--- a/tests/contrib/test_rest_auth_token.yml
+++ b/tests/contrib/test_rest_auth_token.yml
@@ -537,6 +537,7 @@ components:
       properties:
         token:
           type: string
+          writeOnly: true
       required:
       - token
     UserDetails:

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -11,7 +11,7 @@ try:
         JWTAuthentication, JWTTokenUserAuthentication,
     )
     from rest_framework_simplejwt.views import (
-        TokenObtainPairView, TokenObtainSlidingView, TokenRefreshView,
+        TokenObtainPairView, TokenObtainSlidingView, TokenRefreshView, TokenVerifyView,
     )
 except ImportError:
     JWTAuthentication = None
@@ -44,6 +44,7 @@ def test_simplejwt(no_warnings, view):
         path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
         path('token-sliding/', TokenObtainSlidingView.as_view(), name='token_obtain_sliding'),
         path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+        path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     ]
 
     schema = generate_schema(None, patterns=urlpatterns)

--- a/tests/contrib/test_simplejwt.yml
+++ b/tests/contrib/test_simplejwt.yml
@@ -84,6 +84,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenRefresh'
           description: ''
+  /token/verify/:
+    post:
+      operationId: token_verify_create
+      description: |-
+        Takes a token and indicates if it is valid.  This view provides no
+        information about a token's fitness for a particular use.
+      tags:
+      - token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenVerify'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenVerify'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TokenVerify'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenVerify'
+          description: ''
   /x/:
     get:
       operationId: x_list
@@ -152,6 +179,14 @@ components:
       required:
       - access
       - refresh
+    TokenVerify:
+      type: object
+      properties:
+        token:
+          type: string
+          writeOnly: true
+      required:
+      - token
     X:
       type: object
       properties:


### PR DESCRIPTION
Like #512, this was found by validating requests and responses in tests against the schema using some middleware.

In `djangorestframework-simplejwt`, `TokenVerifySerializer` has a `token` field which is [not returned](https://github.com/jazzband/djangorestframework-simplejwt/blob/4d7c7649813f9eae4bd28ed17da685cd3a61f2fe/rest_framework_simplejwt/serializers.py#L153) in the response. Flag this as write-only.

Also see jazzband/djangorestframework-simplejwt#167.