### PR TITLE
Unify handling of bearer token security scheme.

### DIFF
--- a/drf_spectacular/authentication.py
+++ b/drf_spectacular/authentication.py
@@ -1,7 +1,7 @@
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.mixins import TokenSecuritySchemeMixin
 
 
 class SessionScheme(OpenApiAuthenticationExtension):
@@ -29,24 +29,13 @@ class BasicScheme(OpenApiAuthenticationExtension):
         }
 
 
-class TokenScheme(OpenApiAuthenticationExtension):
+class TokenScheme(TokenSecuritySchemeMixin, OpenApiAuthenticationExtension):
     target_class = 'rest_framework.authentication.TokenAuthentication'
     name = 'tokenAuth'
     match_subclasses = True
     priority = -1
 
     def get_security_definition(self, auto_schema):
-        if self.target.keyword == 'Bearer':
-            return {
-                'type': 'http',
-                'scheme': 'bearer',
-            }
-        else:
-            return {
-                'type': 'apiKey',
-                'in': 'header',
-                'name': 'Authorization',
-                'description': _(
-                    'Token-based authentication with required prefix "%s"'
-                ) % self.target.keyword
-            }
+        header_name = 'Authorization'
+        header_type = self.target.keyword
+        return self.build_security_scheme(header_name, header_type)

--- a/drf_spectacular/contrib/rest_framework_jwt.py
+++ b/drf_spectacular/contrib/rest_framework_jwt.py
@@ -1,15 +1,15 @@
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.mixins import TokenSecuritySchemeMixin
 
 
-class JWTScheme(OpenApiAuthenticationExtension):
+class JWTScheme(TokenSecuritySchemeMixin, OpenApiAuthenticationExtension):
     target_class = 'rest_framework_jwt.authentication.JSONWebTokenAuthentication'
     name = 'jwtAuth'
 
     def get_security_definition(self, auto_schema):
         from rest_framework_jwt.settings import api_settings
 
-        return {
-            'type': 'http',
-            'scheme': 'bearer',
-            'bearerFormat': api_settings.JWT_AUTH_HEADER_PREFIX,
-        }
+        header_name = 'Authorization'
+        header_type = api_settings.JWT_AUTH_HEADER_PREFIX
+        extra = {'bearerFormat': 'JWT'}
+        return self.build_security_scheme(header_name, header_type, **extra)

--- a/drf_spectacular/mixins.py
+++ b/drf_spectacular/mixins.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+from django.utils.translation import gettext_lazy as _
+
+
+class TokenSecuritySchemeMixin:
+
+    def build_security_scheme(self, header_name: str, header_type: str, **extra: str) -> Dict[str, str]:
+        if header_name == 'Authorization' and header_type == 'Bearer':
+            return {
+                'type': 'http',
+                'scheme': 'bearer',
+                **extra,
+            }
+        else:
+            return {
+                'type': 'apiKey',
+                'in': 'header',
+                'name': header_name,
+                'description': _('Token-based authentication with required prefix "%s"') % header_type,
+            }

--- a/tests/contrib/test_drf_jwt.py
+++ b/tests/contrib/test_drf_jwt.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.urls import path
 from rest_framework import mixins, routers, serializers, viewsets
@@ -35,3 +37,30 @@ def test_drf_jwt(no_warnings):
     schema = generate_schema(None, patterns=urlpatterns)
 
     assert_schema(schema, 'tests/contrib/test_drf_jwt.yml')
+
+
+@pytest.mark.contrib('rest_framework_jwt')
+@mock.patch('rest_framework_jwt.settings.api_settings.JWT_AUTH_HEADER_PREFIX', 'JWT')
+def test_drf_jwt_non_bearer_keyword(no_warnings):
+    schema = generate_schema('/x', XViewset)
+    assert schema['components']['securitySchemes'] == {
+        'jwtAuth': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization',
+            'description': 'Token-based authentication with required prefix "JWT"'
+        },
+    }
+
+
+@pytest.mark.contrib('rest_framework_jwt')
+@mock.patch('rest_framework_jwt.settings.api_settings.JWT_AUTH_HEADER_PREFIX', 'Bearer')
+def test_drf_jwt_header_bearer_keyword(no_warnings):
+    schema = generate_schema('/x', XViewset)
+    assert schema['components']['securitySchemes'] == {
+        'jwtAuth': {
+            'type': 'http',
+            'scheme': 'bearer',
+            'bearerFormat': 'JWT'
+        },
+    }

--- a/tests/contrib/test_drf_jwt.yml
+++ b/tests/contrib/test_drf_jwt.yml
@@ -85,4 +85,4 @@ components:
     jwtAuth:
       type: http
       scheme: bearer
-      bearerFormat: Bearer
+      bearerFormat: JWT

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -61,23 +61,38 @@ def test_simplejwt_non_bearer_keyword(no_warnings):
             'in': 'header',
             'name': 'Authorization',
             'description': 'Token-based authentication with required prefix "JWT"'
+        },
+    }
+
+
+@pytest.mark.contrib('rest_framework_simplejwt')
+@mock.patch('rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_TYPES', ('Bearer',))
+def test_simplejwt_bearer_keyword(no_warnings):
+    schema = generate_schema('/x', XViewset)
+    assert schema['components']['securitySchemes'] == {
+        'jwtAuth': {
+            'type': 'http',
+            'scheme': 'bearer',
+            'bearerFormat': 'JWT'
         }
     }
 
 
 @pytest.mark.contrib('rest_framework_simplejwt')
+@pytest.mark.parametrize('prefix', ['Bearer', 'JWT'])
 @mock.patch(
     'rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_NAME',
     'HTTP_X_TOKEN',
     create=True,
 )
-def test_simplejwt_non_std_header_name(no_warnings):
-    schema = generate_schema('/x', XViewset)
-    assert schema['components']['securitySchemes'] == {
-        'jwtAuth': {
-            'type': 'apiKey',
-            'in': 'header',
-            'name': 'X-token',
-            'description': 'Token-based authentication with required prefix "Bearer"'
+def test_simplejwt_non_std_header_name(no_warnings, prefix):
+    with mock.patch('rest_framework_simplejwt.settings.api_settings.AUTH_HEADER_TYPES', [prefix]):
+        schema = generate_schema('/x', XViewset)
+        assert schema['components']['securitySchemes'] == {
+            'jwtAuth': {
+                'type': 'apiKey',
+                'in': 'header',
+                'name': 'X-Token',
+                'description': f'Token-based authentication with required prefix "{prefix}"'
+            }
         }
-    }


### PR DESCRIPTION
Fixes `JWTScheme` to behave similar to the implementation of `TokenScheme` and `SimpleJWTScheme`. Also adds additional tests.

This follows on from https://github.com/tfranzel/drf-spectacular/pull/508#issuecomment-919529731.