### PR TITLE
Add setting to disable nested path pk coercion.

### DIFF
--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -98,6 +98,8 @@ class SchemaGenerator(BaseSchemaGenerator):
         of nested routers.
         """
         path = super().coerce_path(path, method, view)  # take care of {pk}
+        if not spectacular_settings.SCHEMA_COERCE_PATH_PK_NESTED:
+            return path
         model = get_view_model(view, emit_warnings=False)
         if not self.coerce_path_pk or not model:
             return path

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -721,12 +721,13 @@ def resolve_regex_path_parameter(model, path_regex, variable):
     explicitly chosen and not the generic non-empty default '[^/.]+'.
     """
     if api_settings.SCHEMA_COERCE_PATH_PK:
-        coercion_mapping = {
-            f'{match}_id': f'{match}_pk'
-            for match in RELATED_MODEL_PARAMETER_RE.findall(path_regex)
-            if hasattr(model, match)
-        }
-        coercion_mapping['id'] = 'pk'
+        coercion_mapping = {'id': 'pk'}
+        if spectacular_settings.SCHEMA_COERCE_PATH_PK_NESTED:
+            coercion_mapping.update({
+                f'{match}_id': f'{match}_pk'
+                for match in RELATED_MODEL_PARAMETER_RE.findall(path_regex)
+                if hasattr(model, match)
+            })
         parameter = coercion_mapping.get(variable, variable)
     else:
         parameter = variable

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -14,6 +14,11 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # conjunction with appended prefixes in SERVERS.
     'SCHEMA_PATH_PREFIX_TRIM': False,
 
+    # Coercion of {pk} to {id} is controlled by SCHEMA_COERCE_PATH_PK. Some support is
+    # implemented in drf-spectacular for coercion of path parameters for nested routers,
+    # e.g. {user_pk} to {user_id}. This can be disabled by setting this to False.
+    'SCHEMA_COERCE_PATH_PK_NESTED': True,
+
     'DEFAULT_GENERATOR_CLASS': 'drf_spectacular.generators.SchemaGenerator',
 
     # Schema generation parameters to influence how components are constructed.

--- a/tests/contrib/test_drf_nested_routers.py
+++ b/tests/contrib/test_drf_nested_routers.py
@@ -1,9 +1,14 @@
+import re
+from unittest import mock
+
 import pytest
 from django.db import models
 from django.urls import include, path, re_path
 from rest_framework import routers, serializers, viewsets
 from rest_framework.routers import SimpleRouter
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from tests import assert_schema, generate_schema
 
 
@@ -29,6 +34,7 @@ class ChildSerializer(serializers.HyperlinkedModelSerializer):
 
 
 @pytest.mark.contrib('drf_nested_routers')
+@mock.patch('drf_spectacular.settings.spectacular_settings.SCHEMA_COERCE_PATH_PK_NESTED', True)
 def test_drf_nested_routers_basic_example(no_warnings):
     from rest_framework_nested.routers import NestedSimpleRouter
 
@@ -52,6 +58,45 @@ def test_drf_nested_routers_basic_example(no_warnings):
     ]
     schema = generate_schema(None, patterns=urlpatterns)
     assert_schema(schema, 'tests/contrib/test_drf_nested_routers.yml')
+    assert schema
+
+
+@pytest.mark.contrib('drf_nested_routers')
+@mock.patch('drf_spectacular.settings.spectacular_settings.SCHEMA_COERCE_PATH_PK_NESTED', False)
+def test_drf_nested_routers_basic_example_disable_coerce_nested_pks(no_warnings):
+    from rest_framework_nested.routers import NestedSimpleRouter
+
+    parameters = [OpenApiParameter('parent_pk', OpenApiTypes.INT, OpenApiParameter.PATH)]
+    transforms = [lambda x: re.sub(r'\bparent_pk\b', 'parent_id', x)]
+
+    class RootViewSet(viewsets.ModelViewSet):
+        serializer_class = RootSerializer
+        queryset = Root.objects.all()
+
+    @extend_schema_view(
+        list=extend_schema(parameters=parameters),
+        create=extend_schema(parameters=parameters),
+        retrieve=extend_schema(parameters=parameters),
+        update=extend_schema(parameters=parameters),
+        partial_update=extend_schema(parameters=parameters),
+        destroy=extend_schema(parameters=parameters),
+    )
+    class ChildViewSet(viewsets.ModelViewSet):
+        serializer_class = ChildSerializer
+        queryset = Child.objects.all()
+
+    router = SimpleRouter()
+    router.register('root', RootViewSet, basename='root')
+
+    root_router = NestedSimpleRouter(router, r'root', lookup='parent')
+    root_router.register(r'child', ChildViewSet, basename='child')
+
+    urlpatterns = [
+        re_path(r'^', include(router.urls)),
+        re_path(r'^', include(root_router.urls)),
+    ]
+    schema = generate_schema(None, patterns=urlpatterns)
+    assert_schema(schema, 'tests/contrib/test_drf_nested_routers.yml', transforms=transforms)
     assert schema
 
 


### PR DESCRIPTION
This is another thing I came across in my conversions from `drf-yasg` which doesn't have any support for converting path parameters for nested routers, but does handle `{pk}` to `{id}` based on `SCHEMA_COERCE_PATH_PK`.

I wanted to disable this behaviour in `drf-spectacular` for the following reasons:

1. It is easier to compare the OpenAPI 2.0 schema produced by `drf-yasg` converted to OpenAPI 3.0 (with a bunch of other clean-ups) against the OpenAPI 3.0 schema produced by `drf-spectacular`.
2. We are using `django-treebeard` and the tree-like structures have no self-referencing foreign key to follow, e.g. for a tree of folders, `{parent_pk}` won't be changed to `{parent_id}`.
3. We have some relationships that are not direct, for example, something like `/{company_pk}/person/{pk}` where the relationship is `Person` → `Department` → `Company`. In this case `Person.company` doesn't exist and there is some custom querying to look up the value.

Where this becomes a mess is when we have something like `/x/{a_pk}/y/{b_pk}/z/{pk}` that becomes `/x/{a_id}/y/{b_pk}/z/{id}` which is inconsistent.

I had thought that it would be nice to have something that allows us to forcibly override this for certain models, e.g. we could pretend that `Person.company` existed. Obviously we'd then need to override the type using `@extend_schema(parameters=...)` That would looks something like:

```python
# drf_spectacular/settings.py:

SPECTACULAR_DEFAULTS = {
    ...
    'SCHEMA_COERCE_PATH_PK_OVERRIDE': {
        'payroll.models.Person': {'company'},
    },
}

# drf_spectacular/generators.py:

class SchemaGenerator(BaseSchemaGenerator):
    ...

    def coerce_path(self, path, method, view):
        """
        Customized coerce_path which also considers the `_pk` suffix in URL paths
        of nested routers.
        """
        path = super().coerce_path(path, method, view)  # take care of {pk}
        if not spectacular_settings.SCHEMA_COERCE_PATH_PK_NESTED:
            return path
        model = get_view_model(view, emit_warnings=False)
        if not self.coerce_path_pk or not model:
            return path
        lookup = f'{model.__module__}.{model.__qualname__}'
        override = spectacular_settings.SCHEMA_COERCE_PATH_PK_OVERRIDE.get(lookup) or set()
        for match in RELATED_MODEL_PARAMETER_RE.findall(path):
            if hasattr(model, match) or match in override:
                path = path.replace(f'{match}_pk', f'{match}_id')
        return path
```

Would something like that also be acceptable?

It seems a shame that, when we set `SCHEMA_COERCE_PATH_PK_NESTED` to `False`, we're forced to manually specify the parameters as though it forgets that `{user_pk}` is still the equivalent to `{user_id}` Maybe I'm missing something...