### PR TITLE
Fix deprecation warning about default_app_config from Django 3.2+

### DIFF
--- a/drf_spectacular/__init__.py
+++ b/drf_spectacular/__init__.py
@@ -1,3 +1,6 @@
+import django
+
 __version__ = '0.18.2'
 
-default_app_config = 'drf_spectacular.apps.SpectacularConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'drf_spectacular.apps.SpectacularConfig'


### PR DESCRIPTION
See
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery