### PR TITLE
Add support for specification extensions.

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -31,7 +31,8 @@ from drf_spectacular.plumbing import (
     build_parameter_type, error, follow_field_source, follow_model_field_lookup, force_instance,
     get_doc, get_type_hints, get_view_model, is_basic_serializer, is_basic_type, is_field,
     is_list_serializer, is_patched_serializer, is_serializer, is_trivial_string_variation,
-    resolve_django_path_parameter, resolve_regex_path_parameter, resolve_type_hint, safe_ref, warn,
+    resolve_django_path_parameter, resolve_regex_path_parameter, resolve_type_hint, safe_ref,
+    sanitize_specification_extensions, warn,
 )
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes
@@ -85,6 +86,10 @@ class AutoSchema(ViewInspector):
             operation['deprecated'] = deprecated
 
         operation['responses'] = self._get_response_bodies()
+
+        extensions = self.get_extensions()
+        if extensions:
+            operation.update(sanitize_specification_extensions(extensions))
 
         return operation
 
@@ -311,6 +316,9 @@ class AutoSchema(ViewInspector):
         tokenized_path = self._tokenize_path()
         # use first non-parameter path part as tag
         return tokenized_path[:1]
+
+    def get_extensions(self) -> typing.Dict[str, typing.Any]:
+        return {}
 
     def get_operation_id(self):
         """ override this for custom behaviour """
@@ -754,6 +762,10 @@ class AutoSchema(ViewInspector):
             schema = serializer_extension.map_serializer(self, direction)
         else:
             schema = self._map_basic_serializer(serializer, direction)
+
+        extensions = get_override(serializer, 'extensions', {})
+        if extensions:
+            schema.update(sanitize_specification_extensions(extensions))
 
         return self._postprocess_serializer_schema(schema, serializer, direction)
 

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -1008,6 +1008,17 @@ def sanitize_result_object(result):
     return result
 
 
+def sanitize_specification_extensions(x):
+    # https://spec.openapis.org/oas/v3.0.3#specification-extensions
+    output = {}
+    for key, value in x.items():
+        if not re.match(r'^x-', key):
+            warn('invalid extension {key!r}')
+        else:
+            output[key] = value
+    return output
+
+
 def camelize_operation(path, operation):
     for path_variable in re.findall(r'\{(\w+)\}', path):
         path = path.replace(

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -210,6 +210,7 @@ def extend_schema(
         methods: Optional[List[str]] = None,
         versions: Optional[List[str]] = None,
         examples: Optional[List[OpenApiExample]] = None,
+        extensions: Optional[Dict[str, Any]] = None,
 ) -> Callable[[F], F]:
     """
     Decorator mainly for the "view" method kind. Partially or completely overrides
@@ -255,6 +256,7 @@ def extend_schema(
     :param methods: scope extend_schema to specific methods. matches all by default.
     :param versions: scope extend_schema to specific API version. matches all by default.
     :param examples: attach request/response examples to the operation
+    :param extensions: specification extensions, e.g. ``x-badges``, ``x-code-samples``, etc.
     :return:
     """
     def decorator(f):
@@ -341,6 +343,11 @@ def extend_schema(
                     return tags
                 return super().get_tags()
 
+            def get_extensions(self):
+                if extensions and is_in_scope(self):
+                    return extensions
+                return super().get_extensions()
+
         if inspect.isclass(f):
             # either direct decoration of views, or unpacked @api_view from OpenApiViewExtension
             if operation_id is not None or operation is not None:
@@ -413,6 +420,7 @@ def extend_schema_serializer(
         exclude_fields: Optional[List[str]] = None,
         deprecate_fields: Optional[List[str]] = None,
         examples: Optional[List[OpenApiExample]] = None,
+        extensions: Optional[Dict[str, Any]] = None,
         component_name: Optional[str] = None,
 ) -> Callable[[F], F]:
     """
@@ -425,6 +433,7 @@ def extend_schema_serializer(
         schema. fields will still be exposed through the API.
     :param deprecate_fields: fields to mark as deprecated while processing the serializer.
     :param examples: define example data to serializer.
+    :param extensions: specification extensions, e.g. ``x-is-dynamic``, etc.
     :param component_name: override default class name extraction.
     """
     def decorator(klass):
@@ -436,6 +445,8 @@ def extend_schema_serializer(
             set_override(klass, 'deprecate_fields', deprecate_fields)
         if examples:
             set_override(klass, 'examples', examples)
+        if extensions:
+            set_override(klass, 'extensions', extensions)
         if component_name:
             set_override(klass, 'component_name', component_name)
         return klass

--- a/tests/test_specification_extensions.py
+++ b/tests/test_specification_extensions.py
@@ -1,0 +1,161 @@
+from unittest import mock
+
+from rest_framework import serializers
+from rest_framework.decorators import api_view, authentication_classes
+from rest_framework.views import APIView
+
+from drf_spectacular.contrib.django_oauth_toolkit import DjangoOAuthToolkitScheme
+from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from tests import generate_schema
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.EXTENSIONS_INFO', {
+    'x-logo': {
+        'altText': 'Django REST Framework Logo',
+        'backgroundColor': "#ffffff",
+        'url': 'https://www.django-rest-framework.org/img/logo.png',
+    },
+})
+def test_info_x_logo(no_warnings):
+    # https://redoc.ly/docs/api-reference-docs/specification-extensions/x-logo/
+
+    class XAPIView(APIView):
+        pass
+
+    schema = generate_schema('x', view=XAPIView)
+    assert schema['info']['x-logo'] == {
+        'altText': 'Django REST Framework Logo',
+        'backgroundColor': "#ffffff",
+        'url': 'https://www.django-rest-framework.org/img/logo.png',
+    }
+
+
+def test_operation_x_badges(no_warnings):
+    # https://mrin9.github.io/RapiDoc/api.html#vendor-extensions
+    # https://mrin9.github.io/RapiDoc/examples/badges.html#overview
+
+    @extend_schema(
+        request=None,
+        responses=None,
+        extensions={
+            'x-badges': [
+                {'color': 'red', 'label': 'Beta'},
+                {'color': 'orange', 'label': 'Slow'},
+            ],
+        },
+    )
+    @api_view(['GET'])
+    def view_func(request, format=None):
+        pass  # pragma: no cover
+
+    schema = generate_schema('x', view_function=view_func)
+    assert schema['paths']['/x']['get']['x-badges'] == [
+        {'color': 'red', 'label': 'Beta'},
+        {'color': 'orange', 'label': 'Slow'},
+    ]
+
+
+def test_operation_x_code_samples(no_warnings):
+    # https://mrin9.github.io/RapiDoc/api.html#vendor-extensions
+    # https://mrin9.github.io/RapiDoc/examples/code-samples.html#get-/code-samples
+    # https://redoc.ly/docs/api-reference-docs/specification-extensions/x-code-samples/
+
+    @extend_schema(
+        request=None,
+        responses=None,
+        extensions={
+            'x-code-samples': [
+                {'lang': 'js', 'label': 'JavaScript', 'source': 'console.log("Hello World");'},
+                {'lang': 'python', 'label': 'Python', 'source': 'print("Hello World")'},
+            ],
+        },
+    )
+    @api_view(['GET'])
+    def view_func(request, format=None):
+        pass  # pragma: no cover
+
+    schema = generate_schema('x', view_function=view_func)
+    assert schema['paths']['/x']['get']['x-code-samples'] == [
+        {'lang': 'js', 'label': 'JavaScript', 'source': 'console.log("Hello World");'},
+        {'lang': 'python', 'label': 'Python', 'source': 'print("Hello World")'},
+    ]
+
+
+def test_operation_x_codegen_request_body_name(no_warnings):
+    # https://openapi-generator.tech/docs/swagger-codegen-migration#body-parameter-name
+    # https://github.com/OpenAPITools/openapi-generator/issues/729
+
+    class UserSerializer(serializers.Serializer):
+        name = serializers.CharField()
+        age = serializers.IntegerField(min_value=0)
+
+    @extend_schema(
+        request=UserSerializer,
+        responses=UserSerializer,
+        extensions={'x-codegen-request-body-name': 'body'},
+    )
+    @api_view(['PATCH'])
+    def view_func(request, format=None):
+        pass  # pragma: no cover
+
+    schema = generate_schema('x', view_function=view_func)
+    operation = schema['paths']['/x']['patch']
+    request_body = operation['requestBody']['content']['application/json']
+    assert request_body['schema']['$ref'] == '#/components/schemas/PatchedUser'
+    assert operation['x-codegen-request-body-name'] == 'body'
+
+
+def test_response_x_is_dynamic(no_warnings):
+    # https://docs.apimatic.io/specification-extensions/swagger-codegen-extensions/#dynamic-response-extension
+
+    @extend_schema_serializer(extensions={'x-is-dynamic': True})
+    class UserSerializer(serializers.Serializer):
+        name = serializers.CharField()
+        age = serializers.IntegerField(min_value=0)
+
+    @extend_schema(request=UserSerializer, responses=UserSerializer)
+    @api_view(['GET'])
+    def view_func(request, format=None):
+        pass  # pragma: no cover
+
+    schema = generate_schema('x', view_function=view_func)
+    response = schema['paths']['/x']['get']['responses']['200']['content']['application/json']
+    component = schema['components']['schemas']['User']
+    assert response['schema']['$ref'] == '#/components/schemas/User'
+    assert component['x-is-dynamic'] is True
+
+
+def test_security_schemes_x_client_id_x_client_secret(no_warnings):
+    # https://mrin9.github.io/RapiDoc/api.html#vendor-extensions
+    # https://mrin9.github.io/RapiDoc/examples/oauth-vendor-extension.html#overview
+    # https://redoc.ly/docs/api-reference-docs/specification-extensions/x-default-clientid/
+
+    try:
+        from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+    except ImportError:
+        CustomOAuth2Authentication = None
+    else:
+        class CustomOAuth2Authentication(OAuth2Authentication):
+            pass
+
+    class CustomOAuthToolkitScheme(DjangoOAuthToolkitScheme):
+        target_class = CustomOAuth2Authentication
+        priority = 10
+
+        def get_security_definition(self, auto_schema):
+            return {
+                **super().get_security_definition(auto_schema),
+                'x-client-id': 'my-client-id',
+                'x-client-secret': 'my-client-secret',
+            }
+
+    @extend_schema(request=None, responses=None)
+    @api_view(['GET'])
+    @authentication_classes([CustomOAuth2Authentication])
+    def view_func(request, format=None):
+        pass  # pragma: no cover
+
+    schema = generate_schema('x', view_function=view_func)
+    oauth2 = schema['components']['securitySchemes']['oauth2']
+    assert oauth2['x-client-id'] == 'my-client-id'
+    assert oauth2['x-client-secret'] == 'my-client-secret'


### PR DESCRIPTION
Add some more support for [specification extensions](https://spec.openapis.org/oas/v3.0.3#specification-extensions) in `@extend_schema` and `@extend_schema_serializer`.

(I had a go at making this work for `@extend_schema_field`, but I ran out of time.)