### PR TITLE
Add scheme attribute to Security Scheme object

### DIFF
--- a/tests/contrib/test_oauth_toolkit.yml
+++ b/tests/contrib/test_oauth_toolkit.yml
@@ -118,6 +118,7 @@ components:
       scheme: basic
     oauth2:
       type: oauth2
+      scheme: bearer
       flows:
         implicit:
           authorizationUrl: http://127.0.0.1:8000/o/authorize


### PR DESCRIPTION
According to the OpenAPI 3.0.3 specs this is required:
https://swagger.io/specification/#security-scheme-object