### PR TITLE
Tidy templates for documentation views.

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/redoc.html
+++ b/drf_spectacular/templates/drf_spectacular/redoc.html
@@ -1,24 +1,19 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{% if title %}{{title}}{% else %}ReDoc{% endif %}</title>
-    <!-- needed for adaptive design -->
-    <meta charset="utf-8"/>
+    <title>{{ title|default:"Redoc" }}</title>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-
-    <!--
-    ReDoc doesn't change outer page styles
-    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;700&family=Roboto:wght@300;400;700&display=swap">
     <style>
-      body {
-        margin: 0;
-        padding: 0;
-      }
+      {# Redoc doesn't change outer page styles. #}
+      body { margin: 0; padding: 0; }
     </style>
   </head>
   <body>
     <redoc spec-url="{{ schema_url }}"></redoc>
-    <script src="{{dist}}/bundles/redoc.standalone.js"></script>
+    <script src="{{ dist }}/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -1,20 +1,23 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{% if title %}{{title}}{% else %}Swagger{% endif %}</title>
-    <meta charset="utf-8"/>
+    <title>{{ title|default:"Swagger" }}</title>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% if favicon_href %}
-    <link rel="icon" type="image/png" href="{{favicon_href}}"/>
-    {% endif %}
-    <link rel="stylesheet" type="text/css" href="{{dist}}/swagger-ui.css" />
+    {% if favicon_href %}<link rel="icon" href="{{ favicon_href }}">{% endif %}
+    <link rel="stylesheet" href="{{ dist }}/swagger-ui.css">
+    <style>
+      html { box-sizing: border-box; overflow-y: scroll; }
+      *, *:after, *:before { box-sizing: inherit; }
+      body { background: #fafafa; margin: 0; }
+    </style>
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="{{dist}}/swagger-ui-bundle.js"></script>
-    <script src="{{dist}}/swagger-ui-standalone-preset.js"></script>
+    <script src="{{ dist }}/swagger-ui-bundle.js"></script>
+    <script src="{{ dist }}/swagger-ui-standalone-preset.js"></script>
     {% if script_url %}
-    <script src="{{script_url|safe}}"></script>
+    <script src="{{ script_url }}"></script>
     {% else %}
     <script>
     {% include template_name_js %}

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.js
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.js
@@ -1,22 +1,18 @@
-const swagger_settings  = {{settings|safe}}
+"use strict";
+
+const swagger_settings = {{ settings|safe }};
 
 const ui = SwaggerUIBundle({
-  url: "{{schema_url|safe}}",
+  url: "{{ schema_url }}",
   dom_id: "#swagger-ui",
-  presets: [
-    SwaggerUIBundle.presets.apis,
-  ],
-  plugin: [
-    SwaggerUIBundle.plugins.DownloadUrl
-  ],
+  presets: [SwaggerUIBundle.presets.apis],
+  plugin: [SwaggerUIBundle.plugins.DownloadUrl],
   layout: "BaseLayout",
   requestInterceptor: (request) => {
-    request.headers["X-CSRFToken"] = "{{csrf_token}}"
+    request.headers["X-CSRFToken"] = "{{ csrf_token }}";
     return request;
   },
-  ...swagger_settings
-})
+  ...swagger_settings,
+});
 
-{% if oauth2_config %}
-ui.initOAuth({{oauth2_config|safe}})
-{% endif %}
+{% if oauth2_config %}ui.initOAuth({{ oauth2_config|safe }});{% endif %}

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -102,7 +102,7 @@ def test_spectacular_ui_view(no_warnings, ui):
     assert response.status_code == 200
     assert response.content.startswith(b'<!DOCTYPE html>')
     if ui == 'redoc':
-        assert b'<title>ReDoc</title>' in response.content
+        assert b'<title>Redoc</title>' in response.content
         assert spectacular_settings.REDOC_DIST.encode() in response.content
     else:
         assert b'<title>Swagger</title>' in response.content
@@ -131,4 +131,4 @@ def test_spectacular_swagger_ui_alternate(no_warnings):
 def test_spectacular_ui_with_raw_settings(no_warnings):
     response = APIClient().get('/api/v2/schema/swagger-ui/')
     assert response.status_code == 200
-    assert b'const swagger_settings  = {"deepLinking": true}\n\n' in response.content
+    assert b'const swagger_settings = {"deepLinking": true};\n\n' in response.content


### PR DESCRIPTION
For both Redoc & Swagger UI templates:

- Make spacing in `{{ ... }}` tags consistent.
- Make use of `|default` filter for default title.
- No need for self-closing tags in HTML5.
- Remove `type="text/css"` for `<link rel="stylesheet" ...>`
  - It's the implicit default since HTML5.

For Redoc template:

- Remove unnecessary comments or convert to Django template comments.
- Update to use newer method for loading fonts from Google.

For Swagger UI templates:

- Don't force `type="image/png"` for Swagger favicon
  - The setting might point to another type, e.g. SVG.
- Don't use the `|safe` filter unnecessarily, i.e. for `script_url`.
- Various minor JavaScript tweaks, e.g. missing trailing semicolons, etc.
- Align with styles from https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.52.3/index.html

Split out from #544.