### PR TITLE
Allow methods in @extend_schema to be case insensitive.

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -53,7 +53,7 @@ class AutoSchema(ViewInspector):
         self.path = path
         self.path_regex = path_regex
         self.path_prefix = path_prefix
-        self.method = method
+        self.method = method.upper()
 
         operation = {'operationId': self.get_operation_id()}
 
@@ -114,7 +114,7 @@ class AutoSchema(ViewInspector):
         if hasattr(self.view, 'action'):
             return self.view.action == 'list'
         # list responses are "usually" only returned by GET
-        if self.method.lower() != 'get':
+        if self.method != 'GET':
             return False
         if isinstance(self.view, ListModelMixin):
             return True
@@ -327,7 +327,7 @@ class AutoSchema(ViewInspector):
         # replace dashes as they can be problematic later in code generation
         tokenized_path = [t.replace('-', '_') for t in tokenized_path]
 
-        if self.method.lower() == 'get' and self._is_list_view():
+        if self.method == 'GET' and self._is_list_view():
             action = 'list'
         else:
             action = self.method_mapping[self.method.lower()]

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -261,6 +261,9 @@ def extend_schema(
     :param extensions: specification extensions, e.g. ``x-badges``, ``x-code-samples``, etc.
     :return:
     """
+    if methods is not None:
+        methods = [method.upper() for method in methods]
+
     def decorator(f):
         BaseSchema = (
             # explicit manually set schema or previous view annotation
@@ -287,7 +290,7 @@ def extend_schema(
 
         class ExtendedSchema(BaseSchema):
             def get_operation(self, path, path_regex, path_prefix, method, registry):
-                self.method = method
+                self.method = method.upper()
 
                 if exclude and is_in_scope(self):
                     return None

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2534,3 +2534,38 @@ def test_double_nested_list_serializer(no_warnings, list_variation):
         'type': 'array',
         'items': {'type': 'array', 'items': {'$ref': '#/components/schemas/X'}}
     }
+
+
+@pytest.mark.parametrize('extend_method, api_view_method', [
+    ('get', 'GET'),
+    ('GET', 'get'),
+])
+def test_api_view_decorator_case_insensitive(no_warnings, extend_method, api_view_method):
+
+    @extend_schema(methods=[extend_method], responses=OpenApiTypes.FLOAT)
+    @api_view([api_view_method])
+    def pi(request):
+        pass  # pragma: no cover
+
+    schema = generate_schema('x', view_function=pi)
+    operation = schema['paths']['/x']['get']
+    assert get_response_schema(operation) == {'type': 'number', 'format': 'float'}
+
+
+@pytest.mark.parametrize('extend_method, action_method', [
+    ('get', 'GET'),
+    ('GET', 'get'),
+])
+def test_action_decorator_case_insensitive(no_warnings, extend_method, action_method):
+
+    class XViewSet(viewsets.ReadOnlyModelViewSet):
+        queryset = SimpleModel.objects.all()
+        serializer_class = SimpleSerializer
+
+        @extend_schema(methods=[extend_method], summary='A custom action!')
+        @action(methods=[action_method], detail=True)
+        def custom_action(self):
+            pass  # pragma: no cover
+
+    schema = generate_schema('x', viewset=XViewSet)
+    schema['paths']['/x/{id}/custom_action/']['get']['summary'] == 'A custom action!'


### PR DESCRIPTION
Without this @extend_schema can be silently ignored if the case of the method doesn't match.

Also generally tightened up the checks against method strings.