### PR TITLE
Add support for `models.JSONField(default=list)`.

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -474,7 +474,10 @@ class AutoSchema(ViewInspector):
             return self._map_model_field(model_field.target_field, direction)
         elif hasattr(models, 'JSONField') and isinstance(model_field, models.JSONField):
             # fix for DRF==3.11 with django>=3.1 as it is not yet represented in the field_mapping
-            return build_basic_type(OpenApiTypes.OBJECT)
+            if issubclass(model_field.default, list):
+                return build_array_type(build_basic_type(OpenApiTypes.ANY))
+            else:
+                return build_basic_type(OpenApiTypes.OBJECT)
         elif isinstance(model_field, models.BinaryField):
             return build_basic_type(OpenApiTypes.BYTE)
         elif hasattr(models, model_field.get_internal_type()):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -111,10 +111,15 @@ class AllFields(models.Model):
 
     if DJANGO_VERSION >= '3.1':
         field_json = models.JSONField()
+        field_json_list = models.JSONField(default=list)
     else:
         @property
         def field_json(self):
             return {'A': 1, 'B': 2}
+
+        @property
+        def field_json_list(self):
+            return [{'A': 1}, {'B': 2}]
 
     @property
     def field_model_property_float(self) -> float:
@@ -229,6 +234,7 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     # there is a JSON model field for django>=3.1 that would be placed automatically. for <=3.1 we
     # need to set the field explicitly. defined here for both cases to have consistent ordering.
     field_json = serializers.JSONField()
+    field_json_list = serializers.ListField()
 
     # traversal of non-model types of complex object
     field_sub_object_calculated = serializers.ReadOnlyField(source='sub_object.calculated')
@@ -330,6 +336,7 @@ def test_model_setup_is_valid():
     )
     if DJANGO_VERSION >= '3.1':
         m.field_json = {'A': 1, 'B': 2}
+        m.field_json_list = [{'A': 1}, {'B': 2}]
     m.field_file.save('hello.txt', ContentFile("hello world"), save=True)
     m.save()
     m.field_m2m.add(aux)

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -176,6 +176,9 @@ components:
         field_json:
           type: object
           additionalProperties: {}
+        field_json_list:
+          type: array
+          items: {}
         field_sub_object_calculated:
           type: integer
           readOnly: true
@@ -312,6 +315,7 @@ components:
       - field_int
       - field_ip_generic
       - field_json
+      - field_json_list
       - field_list
       - field_list_serializer
       - field_m2m

--- a/tests/test_fields_response.json
+++ b/tests/test_fields_response.json
@@ -37,6 +37,14 @@
     "A": 1,
     "B": 2
   },
+  "field_json_list": [
+    {
+      "A": 1
+    },
+    {
+      "B": 2
+    }
+  ],
   "field_sub_object_calculated": 1,
   "field_sub_object_nested_calculated": 1,
   "field_sub_object_model_int": 1,


### PR DESCRIPTION
@tfranzel Hopefully this one is fairly self-explanatory. When `default` is set to `list` we use `array` type instead of `object`.