### PR TITLE
Improve handling of status codes.

### DIFF
--- a/docs/drf_yasg.rst
+++ b/docs/drf_yasg.rst
@@ -154,8 +154,7 @@ Parameter Location
 - :py:data:`~drf_yasg.openapi.IN_QUERY` is called :py:attr:`~drf_spectacular.utils.OpenApiParameter.QUERY`
 - :py:data:`~drf_yasg.openapi.IN_HEADER` is called :py:attr:`~drf_spectacular.utils.OpenApiParameter.HEADER`
 - :py:data:`~drf_yasg.openapi.IN_BODY` and :py:data:`~drf_yasg.openapi.IN_FORM` have no direct equivalent.
-  Instead you can use ``@extend_schema(request={"<media-type>": ...})`` or
-  ``@extend_schema(request={("<status-code>", "<media-type"): ...})``.
+  Instead you can use ``@extend_schema(request={"<media-type>": ...})``.
 - :py:attr:`~drf_spectacular.utils.OpenApiParameter.COOKIE` is also available.
 
 Docstring Parsing

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -15,6 +15,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.schemas.inspectors import ViewInspector
 from rest_framework.schemas.utils import get_pk_description  # type: ignore
 from rest_framework.settings import api_settings
+from rest_framework.status import is_success
 from rest_framework.utils.model_meta import get_field_info
 from rest_framework.views import APIView
 
@@ -1208,7 +1209,7 @@ class AutoSchema(ViewInspector):
         if (
             self._is_list_view(serializer)
             and get_override(serializer, 'many') is not False
-            and (200 <= status_code < 300 or spectacular_settings.ENABLE_LIST_MECHANICS_ON_NON_2XX)
+            and (is_success(status_code) or spectacular_settings.ENABLE_LIST_MECHANICS_ON_NON_2XX)
         ):
             schema = build_array_type(schema)
             paginator = self._get_paginator()

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1172,6 +1172,14 @@ class AutoSchema(ViewInspector):
             serializer, description, examples = (
                 serializer.response, serializer.description, serializer.examples
             )
+            for example in examples:
+                if example.status_codes is None:
+                    example.status_codes = [status_code]
+                elif status_code not in example.status_codes:
+                    warn(
+                        f'example in response with status code {status_code} had'
+                        f'status_codes set to {example.status_codes!r}'
+                    )
         else:
             description, examples = '', []
 

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1033,7 +1033,7 @@ class AutoSchema(ViewInspector):
                 continue
             if media_type and media_type != example.media_type:
                 continue
-            if status_code and status_code not in example.status_codes:
+            if status_code and status_code not in (example.status_codes or [200, 201]):
                 continue
             filtered_examples.append(example)
 

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -124,7 +124,7 @@ class OpenApiExample(OpenApiSchemaBase):
         self.response_only = response_only
         self.parameter_only = parameter_only
         self.media_type = media_type
-        self.status_codes = status_codes or ['200', '201']
+        self.status_codes = status_codes
 
 
 class OpenApiParameter(OpenApiSchemaBase):

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+from http import HTTPStatus
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 from rest_framework.fields import Field, empty
@@ -113,7 +114,7 @@ class OpenApiExample(OpenApiSchemaBase):
             response_only: bool = False,
             parameter_only: Optional[Tuple[str, _ParameterLocationType]] = None,
             media_type: str = 'application/json',
-            status_codes: Optional[List[Union[int, str]]] = None,
+            status_codes: Optional[List[Union[HTTPStatus, int, str]]] = None,
     ):
         self.name = name
         self.summary = summary

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -113,7 +113,7 @@ class OpenApiExample(OpenApiSchemaBase):
             response_only: bool = False,
             parameter_only: Optional[Tuple[str, _ParameterLocationType]] = None,
             media_type: str = 'application/json',
-            status_codes: Optional[List[str]] = None,
+            status_codes: Optional[List[Union[int, str]]] = None,
     ):
         self.name = name
         self.summary = summary
@@ -124,7 +124,7 @@ class OpenApiExample(OpenApiSchemaBase):
         self.response_only = response_only
         self.parameter_only = parameter_only
         self.media_type = media_type
-        self.status_codes = status_codes
+        self.status_codes = list(map(int, status_codes)) if status_codes else None
 
 
 class OpenApiParameter(OpenApiSchemaBase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -74,6 +74,7 @@ class ExampleTestWithExtendedViewSet(viewsets.GenericViewSet):
             201: BSerializer,
             400: OpenApiTypes.OBJECT,
             403: OpenApiTypes.OBJECT,
+            404: OpenApiTypes.OBJECT,
         },
         examples=[
             OpenApiExample(
@@ -94,7 +95,13 @@ class ExampleTestWithExtendedViewSet(viewsets.GenericViewSet):
                 'Create Error 403 Example',
                 value={'field': 'error'},
                 response_only=True,
-                status_codes=['403']
+                status_codes=['403'],  # string
+            ),
+            OpenApiExample(
+                'Create Error 404 Example',
+                value={'field': 'error'},
+                response_only=True,
+                status_codes=[404],  # integer
             ),
         ],
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -75,6 +77,7 @@ class ExampleTestWithExtendedViewSet(viewsets.GenericViewSet):
             400: OpenApiTypes.OBJECT,
             403: OpenApiTypes.OBJECT,
             404: OpenApiTypes.OBJECT,
+            500: OpenApiTypes.OBJECT,
         },
         examples=[
             OpenApiExample(
@@ -102,6 +105,12 @@ class ExampleTestWithExtendedViewSet(viewsets.GenericViewSet):
                 value={'field': 'error'},
                 response_only=True,
                 status_codes=[404],  # integer
+            ),
+            OpenApiExample(
+                'Create Error 500 Example',
+                value={'field': 'error'},
+                response_only=True,
+                status_codes=[HTTPStatus.INTERNAL_SERVER_ERROR],  # enum
             ),
         ],
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
-    OpenApiExample, OpenApiParameter, extend_schema, extend_schema_serializer,
+    OpenApiExample, OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_serializer,
 )
 from tests import assert_schema, generate_schema
 from tests.models import SimpleModel
@@ -159,7 +159,32 @@ class ExampleTestWithExtendedViewSet(viewsets.GenericViewSet):
     def raw_action(self, request):
         return Response()  # pragma: no cover
 
-    @extend_schema(responses=BSerializer)
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(
+                description="",
+                response=BSerializer,
+                examples=[
+                    OpenApiExample(
+                        'Override 200 Example',
+                        value={'field': 'ok'},
+                    ),
+                ],
+            ),
+            400: OpenApiResponse(
+                description="",
+                response=BSerializer,
+                examples=[
+                    OpenApiExample(
+                        'Override 400 Example',
+                        value={'field': 'status_codes_undeclared_in_response_examples'},
+                        # Ensure this works when status_codes are not provided.
+                        # Previously this only worked automatically for 200 and 201.
+                    ),
+                ],
+            ),
+        },
+    )
     @action(detail=False, methods=['POST'])
     def override_extend_schema_action(self, request):
         return Response()  # pragma: no cover

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -105,6 +105,18 @@ paths:
                     field: error
                   summary: Create Error 403 Example
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                CreateError404Example:
+                  value:
+                    field: error
+                  summary: Create Error 404 Example
+          description: ''
   /schema/{id}/:
     get:
       operationId: schema_retrieve

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -199,6 +199,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/B'
+              examples:
+                Override200Example:
+                  value:
+                    field: ok
+                  summary: Override 200 Example
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/B'
+              examples:
+                Override400Example:
+                  value:
+                    field: status_codes_undeclared_in_response_examples
+                  summary: Override 400 Example
           description: ''
   /schema/raw_action/:
     get:

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -117,6 +117,18 @@ paths:
                     field: error
                   summary: Create Error 404 Example
           description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+              examples:
+                CreateError500Example:
+                  value:
+                    field: error
+                  summary: Create Error 500 Example
+          description: ''
   /schema/{id}/:
     get:
       operationId: schema_retrieve


### PR DESCRIPTION
I've bumped into a number of things related to status codes that I think could work better.

- Status codes are largely passed around as strings.
- In some places only strings are accepted, e.g. `OpenApiExample`'s `status_codes` list.
- `OpenApiExample` requires `status_codes` to be defined to something to work with non-200/201 statuses in `OpenApiResponse` which doesn't make sense and seems unnecessary if the example can only be for that defined response and its status code.

These changes do the following:

- Allow string, integer (including `rest_framework.status.*` constants) or enum (e.g. `HTTPStatus`) to work in:
  - The keys of the `responses` dict of `@extend_schema`.
  - The `status_codes` list of `OpenApiExample`.
- Allow the `status_codes` list to be left undefined so that the `examples` in `OpenApiResponse` assume they work for the status code for that response.

This probably isn't perfect and you'll want to fix some bits I'm sure, but I thought there was enough here to be getting on with.