### PR TITLE
Document alternative to drf-yasg swagger_schema_field

### DIFF
--- a/docs/drf_yasg.rst
+++ b/docs/drf_yasg.rst
@@ -48,6 +48,10 @@ Decorators
 - Instead of using :py:func:`@method_decorator <django.utils.decorators.method_decorator>`, use
   :py:func:`@extend_schema_view <drf_spectacular.utils.extend_schema_view>`.
 
+- Instead of using `swagger_schema_field`, use
+  :py:func:`@extend_schema_field <drf_spectacular.utils.extend_schema_field>` or
+  :py:func:`@extend_schema_serializer <drf_spectacular.utils.extend_schema_serializer>`.
+
 Helper Classes
 --------------
 


### PR DESCRIPTION
Closes #568 

I believe that this provides enough details for someone to know where to get started without trying to get into the complex details of `swagger_schema_field`.