### PR TITLE
Add support for django-auth-adfs

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -119,3 +119,11 @@ logic is required as this differs from the default DRF ``FileField``.
 .. literalinclude:: blueprints/drf_extra_fields.py
 
 __ https://github.com/Hipo/drf-extra-fields
+
+django-auth-adfs
+----------------
+
+`django-auth-adfs <https://github.com/snok/django-auth-adfs>`_ provides "a Django authentication backend for Microsoft ADFS and Azure AD".
+The blueprint works for the Azure AD configuration guide (see: https://django-auth-adfs.readthedocs.io/en/latest/azure_ad_config_guide.html).
+
+.. literalinclude:: blueprints/django_auth_adfs.py

--- a/docs/blueprints/django_auth_adfs.py
+++ b/docs/blueprints/django_auth_adfs.py
@@ -1,0 +1,11 @@
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.plumbing import build_bearer_security_scheme_object
+
+class AdfsAccessTokenAuthenticationScheme(OpenApiAuthenticationExtension):
+    target_class = 'django_auth_adfs.rest_framework.AdfsAccessTokenAuthentication'
+    name = 'jwtAuth'
+
+    def get_security_definition(self, auto_schema):
+        return build_bearer_security_scheme_object(header_name='AUTHORIZATION',
+                                                   token_prefix='Bearer',
+                                                   bearer_format='JWT')


### PR DESCRIPTION
Add support for django-auth-adfs (https://github.com/snok/django-auth-adfs).
The support works for the Azure AD configuration guide (https://django-auth-adfs.readthedocs.io/en/latest/azure_ad_config_guide.html).

Added:
- a file (django_auth_adfs.py) with the class to support the AdfsAccessTokenAuthentication class of django-auth-adfs;
- a line in in the README to mention support for the package.