### PR TITLE
improve mypy typing #600

### DIFF
--- a/drf_spectacular/contrib/rest_polymorphic.py
+++ b/drf_spectacular/contrib/rest_polymorphic.py
@@ -1,6 +1,7 @@
+from drf_spectacular.drainage import warn
 from drf_spectacular.extensions import OpenApiSerializerExtension
 from drf_spectacular.plumbing import (
-    ResolvedComponent, build_basic_type, build_object_type, is_patched_serializer, warn,
+    ResolvedComponent, build_basic_type, build_object_type, is_patched_serializer,
 )
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes

--- a/drf_spectacular/extensions.py
+++ b/drf_spectacular/extensions.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
     from drf_spectacular.openapi import AutoSchema
 
 
+_SchemaType = Dict[str, Any]
+
+
 class OpenApiAuthenticationExtension(OpenApiGeneratorExtension['OpenApiAuthenticationExtension']):
     """
     Extension for specifying authentication schemes.
@@ -29,7 +32,7 @@ class OpenApiAuthenticationExtension(OpenApiGeneratorExtension['OpenApiAuthentic
     ``get_security_definition()`` is expected to return a valid `OpenAPI security scheme object
     <https://spec.openapis.org/oas/v3.0.3#securitySchemeObject>`_
     """
-    _registry: List['OpenApiAuthenticationExtension'] = []
+    _registry: List[Type['OpenApiAuthenticationExtension']] = []
 
     name: Union[str, List[str]]
 
@@ -43,7 +46,7 @@ class OpenApiAuthenticationExtension(OpenApiGeneratorExtension['OpenApiAuthentic
             return {name: [] for name in self.name}
 
     @abstractmethod
-    def get_security_definition(self, auto_schema: 'AutoSchema') -> Union[dict, List[dict]]:
+    def get_security_definition(self, auto_schema: 'AutoSchema') -> Union[_SchemaType, List[_SchemaType]]:
         pass  # pragma: no cover
 
 
@@ -59,13 +62,13 @@ class OpenApiSerializerExtension(OpenApiGeneratorExtension['OpenApiSerializerExt
     ``map_serializer()`` is expected to return a valid `OpenAPI schema object
     <https://spec.openapis.org/oas/v3.0.3#schemaObject>`_.
     """
-    _registry: List['OpenApiSerializerExtension'] = []
+    _registry: List[Type['OpenApiSerializerExtension']] = []
 
     def get_name(self, auto_schema: 'AutoSchema', direction: Direction) -> Optional[str]:
         """ return str for overriding default name extraction """
         return None
 
-    def map_serializer(self, auto_schema: 'AutoSchema', direction: Direction):
+    def map_serializer(self, auto_schema: 'AutoSchema', direction: Direction) -> _SchemaType:
         """ override for customized serializer mapping """
         return auto_schema._map_serializer(self.target_class, direction, bypass_extensions=True)
 
@@ -82,14 +85,14 @@ class OpenApiSerializerFieldExtension(OpenApiGeneratorExtension['OpenApiSerializ
     ``map_serializer_field()`` is expected to return a valid `OpenAPI schema object
     <https://spec.openapis.org/oas/v3.0.3#schemaObject>`_.
     """
-    _registry: List['OpenApiSerializerFieldExtension'] = []
+    _registry: List[Type['OpenApiSerializerFieldExtension']] = []
 
     def get_name(self) -> Optional[str]:
         """ return str for breaking out field schema into separate named component """
         return None
 
     @abstractmethod
-    def map_serializer_field(self, auto_schema: 'AutoSchema', direction: Direction):
+    def map_serializer_field(self, auto_schema: 'AutoSchema', direction: Direction) -> _SchemaType:
         """ override for customized serializer field mapping """
         pass  # pragma: no cover
 
@@ -102,7 +105,7 @@ class OpenApiViewExtension(OpenApiGeneratorExtension['OpenApiViewExtension']):
     ``ViewSet`` et al.). The discovered original view instance can be accessed with
     ``self.target`` and be subclassed if desired.
     """
-    _registry: List['OpenApiViewExtension'] = []
+    _registry: List[Type['OpenApiViewExtension']] = []
 
     @classmethod
     def _load_class(cls):
@@ -129,8 +132,8 @@ class OpenApiFilterExtension(OpenApiGeneratorExtension['OpenApiFilterExtension']
     Using ``drf_spectacular.plumbing.build_parameter_type`` is recommended to generate
     the appropriate raw dict objects.
     """
-    _registry: List['OpenApiFilterExtension'] = []
+    _registry: List[Type['OpenApiFilterExtension']] = []
 
     @abstractmethod
-    def get_schema_operation_parameters(self, auto_schema: 'AutoSchema', *args, **kwargs) -> List[dict]:
+    def get_schema_operation_parameters(self, auto_schema: 'AutoSchema', *args, **kwargs) -> List[_SchemaType]:
         pass  # pragma: no cover

--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -3,17 +3,19 @@ import re
 
 from django.urls import URLPattern, URLResolver
 from rest_framework import views, viewsets
-from rest_framework.schemas.generators import BaseSchemaGenerator  # type: ignore
+from rest_framework.schemas.generators import BaseSchemaGenerator
 from rest_framework.schemas.generators import EndpointEnumerator as BaseEndpointEnumerator
 from rest_framework.settings import api_settings
 
-from drf_spectacular.drainage import add_trace_message, get_override, reset_generator_stats
+from drf_spectacular.drainage import (
+    add_trace_message, error, get_override, reset_generator_stats, warn,
+)
 from drf_spectacular.extensions import OpenApiViewExtension
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import (
-    ComponentRegistry, alpha_operation_sorter, build_root_object, camelize_operation, error,
-    get_class, is_versioning_supported, modify_for_versioning, normalize_result_object,
-    operation_matches_version, sanitize_result_object, warn,
+    ComponentRegistry, alpha_operation_sorter, build_root_object, camelize_operation, get_class,
+    is_versioning_supported, modify_for_versioning, normalize_result_object,
+    operation_matches_version, sanitize_result_object,
 )
 from drf_spectacular.settings import spectacular_settings
 

--- a/drf_spectacular/hooks.py
+++ b/drf_spectacular/hooks.py
@@ -4,8 +4,9 @@ from collections import defaultdict
 from inflection import camelize
 from rest_framework.settings import api_settings
 
+from drf_spectacular.drainage import warn
 from drf_spectacular.plumbing import (
-    ResolvedComponent, list_hash, load_enum_name_overrides, safe_ref, warn,
+    ResolvedComponent, list_hash, load_enum_name_overrides, safe_ref,
 )
 from drf_spectacular.settings import spectacular_settings
 

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -12,7 +12,15 @@ from abc import ABCMeta
 from collections import OrderedDict, defaultdict
 from decimal import Decimal
 from enum import Enum
-from typing import Any, DefaultDict, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any, DefaultDict, Dict, Generic, List, Optional, Sequence, Tuple, Type, TypeVar, Union,
+)
+
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard  # noqa: F401
+else:
+    from typing_extensions import TypeGuard  # noqa: F401
+
 
 import inflection
 import uritemplate
@@ -46,8 +54,12 @@ from drf_spectacular.drainage import cache, error, get_override, warn
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import (
     DJANGO_PATH_CONVERTER_MAPPING, OPENAPI_TYPE_MAPPING, PYTHON_TYPE_MAPPING, OpenApiTypes,
+    _KnownPythonTypes,
 )
-from drf_spectacular.utils import OpenApiParameter
+from drf_spectacular.utils import (
+    OpenApiExample, OpenApiParameter, _FieldType, _ListSerializerType, _ParameterLocationType,
+    _SchemaType, _SerializerType,
+)
 
 try:
     from django.db.models.enums import Choices  # only available in Django>3
@@ -57,9 +69,9 @@ except ImportError:
 
 # types.UnionType was added in Python 3.10 for new PEP 604 pipe union syntax
 if hasattr(types, 'UnionType'):
-    UNION_TYPES: Tuple[Any, ...] = (typing.Union, types.UnionType)  # type: ignore
+    UNION_TYPES: Tuple[Any, ...] = (Union, types.UnionType)
 else:
-    UNION_TYPES = (typing.Union,)
+    UNION_TYPES = (Union,)
 
 LITERAL_TYPES: Tuple[Any, ...] = ()
 TYPED_DICT_META_TYPES: Tuple[Any, ...] = ()
@@ -79,9 +91,9 @@ except ImportError:
     pass
 
 if sys.version_info >= (3, 8):
-    CACHED_PROPERTY_FUNCS = (functools.cached_property, cached_property)  # type: ignore
+    CACHED_PROPERTY_FUNCS = (functools.cached_property, cached_property)
 else:
-    CACHED_PROPERTY_FUNCS = (cached_property,)  # type: ignore
+    CACHED_PROPERTY_FUNCS = (cached_property,)
 
 T = TypeVar('T')
 
@@ -103,19 +115,20 @@ def force_instance(serializer_or_field):
         return serializer_or_field
 
 
-def is_serializer(obj, strict=False) -> bool:
-    from drf_spectacular.serializers import OpenApiSerializerExtension
+def is_serializer(obj, strict=False) -> TypeGuard[_SerializerType]:
+
+    from drf_spectacular.extensions import OpenApiSerializerExtension
     return (
         isinstance(force_instance(obj), serializers.BaseSerializer)
         or (bool(OpenApiSerializerExtension.get_match(obj)) and not strict)
     )
 
 
-def is_list_serializer(obj) -> bool:
+def is_list_serializer(obj: Any) -> TypeGuard[_ListSerializerType]:
     return isinstance(force_instance(obj), serializers.ListSerializer)
 
 
-def get_list_serializer(obj):
+def get_list_serializer(obj: Any):
     return force_instance(obj) if is_list_serializer(obj) else get_class(obj)(many=True, context=obj.context)
 
 
@@ -127,17 +140,17 @@ def is_list_serializer_customized(obj) -> bool:
     )
 
 
-def is_basic_serializer(obj) -> bool:
+def is_basic_serializer(obj: Any) -> TypeGuard[_SerializerType]:
     return is_serializer(obj) and not is_list_serializer(obj)
 
 
-def is_field(obj):
+def is_field(obj: Any) -> TypeGuard[_FieldType]:
     # make sure obj is a serializer field and nothing else.
     # guard against serializers because BaseSerializer(Field)
     return isinstance(force_instance(obj), fields.Field) and not is_serializer(obj)
 
 
-def is_basic_type(obj, allow_none=True):
+def is_basic_type(obj: Any, allow_none=True) -> TypeGuard[_KnownPythonTypes]:
     if not isinstance(obj, collections.abc.Hashable):
         return False
     if not allow_none and (obj is None or obj is OpenApiTypes.NONE):
@@ -145,7 +158,7 @@ def is_basic_type(obj, allow_none=True):
     return obj in get_openapi_type_mapping() or obj in PYTHON_TYPE_MAPPING
 
 
-def is_patched_serializer(serializer, direction):
+def is_patched_serializer(serializer, direction) -> bool:
     return bool(
         spectacular_settings.COMPONENT_SPLIT_PATCH
         and getattr(serializer, 'partial', None)
@@ -154,13 +167,13 @@ def is_patched_serializer(serializer, direction):
     )
 
 
-def is_trivial_string_variation(a: str, b: str):
+def is_trivial_string_variation(a: str, b: str) -> bool:
     a = (a or '').strip().lower().replace(' ', '_').replace('-', '_')
     b = (b or '').strip().lower().replace(' ', '_').replace('-', '_')
     return a == b
 
 
-def assert_basic_serializer(serializer):
+def assert_basic_serializer(serializer) -> None:
     assert is_basic_serializer(serializer), (
         f'internal assumption violated because we expected a basic serializer here and '
         f'instead got a "{serializer}". This may be the result of another app doing '
@@ -208,9 +221,9 @@ def get_view_model(view, emit_warnings=True):
             )
 
 
-def get_doc(obj):
+def get_doc(obj) -> str:
     """ get doc string with fallback on obj's base classes (ignoring DRF documentation). """
-    def post_cleanup(doc: str):
+    def post_cleanup(doc: str) -> str:
         # also clean up trailing whitespace for each line
         return '\n'.join(line.rstrip() for line in doc.rstrip().split('\n'))
 
@@ -232,7 +245,7 @@ def get_doc(obj):
     return ''
 
 
-def get_type_hints(obj):
+def get_type_hints(obj) -> Dict[str, Any]:
     """ unpack wrapped partial object and use actual func object """
     if isinstance(obj, functools.partial):
         obj = obj.func
@@ -266,7 +279,7 @@ def build_generic_type():
         return {'type': 'object', 'additionalProperties': {}}
 
 
-def build_basic_type(obj):
+def build_basic_type(obj: Union[_KnownPythonTypes, OpenApiTypes]) -> Optional[_SchemaType]:
     """
     resolve either enum or actual type and yield schema template for modification
     """
@@ -282,7 +295,7 @@ def build_basic_type(obj):
         return dict(openapi_type_mapping[OpenApiTypes.STR])
 
 
-def build_array_type(schema, min_length=None, max_length=None):
+def build_array_type(schema: _SchemaType, min_length=None, max_length=None) -> _SchemaType:
     schema = {'type': 'array', 'items': schema}
     if min_length is not None:
         schema['minLength'] = min_length
@@ -292,12 +305,12 @@ def build_array_type(schema, min_length=None, max_length=None):
 
 
 def build_object_type(
-        properties=None,
+        properties: Optional[_SchemaType] = None,
         required=None,
-        description=None,
+        description: Optional[str] = None,
         **kwargs
-):
-    schema = {'type': 'object'}
+) -> _SchemaType:
+    schema: _SchemaType = {'type': 'object'}
     if description:
         schema['description'] = description.strip()
     if properties:
@@ -310,7 +323,7 @@ def build_object_type(
     return schema
 
 
-def build_media_type_object(schema, examples=None, encoding=None):
+def build_media_type_object(schema, examples=None, encoding=None) -> _SchemaType:
     media_type_object = {'schema': schema}
     if examples:
         media_type_object['examples'] = examples
@@ -319,7 +332,7 @@ def build_media_type_object(schema, examples=None, encoding=None):
     return media_type_object
 
 
-def build_examples_list(examples):
+def build_examples_list(examples: Sequence[OpenApiExample]) -> _SchemaType:
     schema = {}
     for example in examples:
         normalized_name = inflection.camelize(example.name.replace(' ', '_'))
@@ -339,9 +352,9 @@ def build_examples_list(examples):
 
 
 def build_parameter_type(
-        name,
-        schema,
-        location,
+        name: str,
+        schema: _SchemaType,
+        location: _ParameterLocationType,
         required=False,
         description=None,
         enum=None,
@@ -353,7 +366,7 @@ def build_parameter_type(
         allow_blank=True,
         examples=None,
         extensions=None,
-):
+) -> _SchemaType:
     irrelevant_field_meta = ['readOnly', 'writeOnly']
     if location == OpenApiParameter.PATH:
         irrelevant_field_meta += ['nullable', 'default']
@@ -395,11 +408,11 @@ def build_parameter_type(
     return schema
 
 
-def build_choice_field(field):
+def build_choice_field(field) -> _SchemaType:
     choices = list(OrderedDict.fromkeys(field.choices))  # preserve order and remove duplicates
 
     if all(isinstance(choice, bool) for choice in choices):
-        type = 'boolean'
+        type: Optional[str] = 'boolean'
     elif all(isinstance(choice, int) for choice in choices):
         type = 'integer'
     elif all(isinstance(choice, (int, float, Decimal)) for choice in choices):  # `number` includes `integer`
@@ -415,7 +428,7 @@ def build_choice_field(field):
     if field.allow_null and None not in choices:
         choices.append(None)
 
-    schema = {
+    schema: _SchemaType = {
         # The value of `enum` keyword MUST be an array and SHOULD be unique.
         # Ref: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.20
         'enum': choices
@@ -464,7 +477,7 @@ def build_bearer_security_scheme_object(header_name, token_prefix, bearer_format
         }
 
 
-def build_root_object(paths, components, version):
+def build_root_object(paths, components, version) -> _SchemaType:
     settings = spectacular_settings
     if settings.VERSION and version:
         version = f'{settings.VERSION} ({version})'
@@ -498,7 +511,7 @@ def build_root_object(paths, components, version):
     return root
 
 
-def safe_ref(schema):
+def safe_ref(schema: _SchemaType) -> _SchemaType:
     """
     ensure that $ref has its own context and does not remove potential sibling
     entries when $ref is substituted. also remove useless singular "allOf" .
@@ -510,7 +523,7 @@ def safe_ref(schema):
     return schema
 
 
-def append_meta(schema, meta):
+def append_meta(schema: _SchemaType, meta: _SchemaType) -> _SchemaType:
     if spectacular_settings.OAS_VERSION.startswith('3.1'):
         schema_nullable = meta.pop('nullable', None)
         meta_nullable = schema.pop('nullable', None)
@@ -554,9 +567,9 @@ def _follow_field_source(model, path: List[str]):
         elif isinstance(field_or_property, ReverseOneToOneDescriptor):
             return field_or_property.related.target_field  # o2o reverse
         elif isinstance(field_or_property, ReverseManyToOneDescriptor):
-            return field_or_property.rel.target_field  # type: ignore # foreign reverse
+            return field_or_property.rel.target_field  # foreign reverse
         elif isinstance(field_or_property, ForwardManyToOneDescriptor):
-            return field_or_property.field.target_field  # type: ignore # o2o & foreign forward
+            return field_or_property.field.target_field  # o2o & foreign forward
         else:
             field = model._meta.get_field(path[0])
             if isinstance(field, ForeignObjectRel):
@@ -676,20 +689,20 @@ class ResolvedComponent:
         return bool(self.name and self.type and self.object)
 
     @property
-    def key(self):
+    def key(self) -> Tuple[str, str]:
         return self.name, self.type
 
     @property
-    def ref(self) -> dict:
+    def ref(self) -> _SchemaType:
         assert self.__bool__()
         return {'$ref': f'#/components/{self.type}/{self.name}'}
 
 
 class ComponentRegistry:
-    def __init__(self):
-        self._components = {}
+    def __init__(self) -> None:
+        self._components: Dict[Tuple[str, str], ResolvedComponent] = {}
 
-    def register(self, component: ResolvedComponent):
+    def register(self, component: ResolvedComponent) -> None:
         if component in self:
             warn(
                 f'trying to re-register a {component.type} component with name '
@@ -698,7 +711,7 @@ class ComponentRegistry:
             )
         self._components[component.key] = component
 
-    def register_on_missing(self, component: ResolvedComponent):
+    def register_on_missing(self, component: ResolvedComponent) -> None:
         if component not in self:
             self._components[component.key] = component
 
@@ -723,7 +736,7 @@ class ComponentRegistry:
             )
         return True
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> ResolvedComponent:
         if isinstance(key, ResolvedComponent):
             key = key.key
         return self._components[key]
@@ -733,8 +746,8 @@ class ComponentRegistry:
             key = key.key
         del self._components[key]
 
-    def build(self, extra_components) -> dict:
-        output: DefaultDict[str, dict] = defaultdict(dict)
+    def build(self, extra_components) -> _SchemaType:
+        output: DefaultDict[str, _SchemaType] = defaultdict(dict)
         # build tree from flat registry
         for component in self._components.values():
             output[component.type][component.name] = component.schema
@@ -750,7 +763,7 @@ class ComponentRegistry:
 
 
 class OpenApiGeneratorExtension(Generic[T], metaclass=ABCMeta):
-    _registry: List[T] = []
+    _registry: List[Type[T]] = []
     target_class: Union[None, str, Type[object]] = None
     match_subclasses = False
     priority = 0
@@ -785,7 +798,7 @@ class OpenApiGeneratorExtension(Generic[T], metaclass=ABCMeta):
             cls.target_class = None
 
     @classmethod
-    def _matches(cls, target) -> bool:
+    def _matches(cls, target: Any) -> bool:
         if isinstance(cls.target_class, str):
             cls._load_class()
 
@@ -808,7 +821,7 @@ class OpenApiGeneratorExtension(Generic[T], metaclass=ABCMeta):
         return None
 
 
-def deep_import_string(string):
+def deep_import_string(string: str) -> Any:
     """ augmented import from string, e.g. MODULE.CLASS/OBJECT.ATTRIBUTE """
     try:
         return import_string(string)
@@ -864,7 +877,7 @@ def load_enum_name_overrides():
     return overrides
 
 
-def list_hash(lst):
+def list_hash(lst: Any) -> str:
     return hashlib.sha256(json.dumps(list(lst), sort_keys=True, cls=JSONEncoder).encode()).hexdigest()[:16]
 
 
@@ -965,7 +978,7 @@ def resolve_regex_path_parameter(path_regex, variable):
     return None
 
 
-def is_versioning_supported(versioning_class):
+def is_versioning_supported(versioning_class) -> bool:
     return issubclass(versioning_class, (
         versioning.URLPathVersioning,
         versioning.NamespaceVersioning,
@@ -973,7 +986,7 @@ def is_versioning_supported(versioning_class):
     ))
 
 
-def operation_matches_version(view, requested_version):
+def operation_matches_version(view, requested_version) -> bool:
     try:
         version, _ = view.determine_version(view.request, **view.kwargs)
     except exceptions.NotAcceptable:
@@ -1039,7 +1052,7 @@ def modify_media_types_for_versioning(view, media_types: List[str]) -> List[str]
     ]
 
 
-def analyze_named_regex_pattern(path):
+def analyze_named_regex_pattern(path: str) -> Dict[str, str]:
     """ safely extract named groups and their pattern from given regex pattern """
     result = {}
     stack = 0
@@ -1320,7 +1333,7 @@ def resolve_type_hint(hint):
         raise UnableToProceedError()
 
 
-def whitelisted(obj: object, classes: Optional[List[Type[object]]], exact=False):
+def whitelisted(obj: object, classes: Optional[List[Type[object]]], exact=False) -> bool:
     if classes is None:
         return True
     if exact:
@@ -1338,7 +1351,7 @@ def build_mocked_view(method: str, path: str, extend_schema_decorator, registry)
 
     # emulate what Generator would do to setup schema generation.
     view_callable = TmpView.as_view()
-    view = view_callable.cls()  # type: ignore
+    view: views.APIView = view_callable.cls()
     view.request = spectacular_settings.GET_MOCK_REQUEST(
         method.upper(), path, view, None
     )

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -11,7 +11,7 @@ else:
     from typing_extensions import Final, Literal
 
 from rest_framework.fields import Field, empty
-from rest_framework.serializers import Serializer
+from rest_framework.serializers import ListSerializer, Serializer
 from rest_framework.settings import api_settings
 
 from drf_spectacular.drainage import (
@@ -19,10 +19,12 @@ from drf_spectacular.drainage import (
 )
 from drf_spectacular.types import OpenApiTypes, _KnownPythonTypes
 
+_ListSerializerType = Union[ListSerializer, Type[ListSerializer]]
 _SerializerType = Union[Serializer, Type[Serializer]]
 _FieldType = Union[Field, Type[Field]]
 _ParameterLocationType = Literal['query', 'path', 'header', 'cookie']
 _StrOrPromise = Union[str, Promise]
+_SchemaType = Dict[str, Any]
 Direction = Literal['request', 'response']
 
 
@@ -202,7 +204,7 @@ class OpenApiParameter(OpenApiSchemaBase):
     def __init__(
             self,
             name: str,
-            type: Union[_SerializerType, _KnownPythonTypes, OpenApiTypes, dict] = str,
+            type: Union[_SerializerType, _KnownPythonTypes, OpenApiTypes, _SchemaType] = str,
             location: _ParameterLocationType = QUERY,
             required: bool = False,
             description: _StrOrPromise = '',
@@ -326,7 +328,7 @@ def extend_schema(
         tags: Optional[Sequence[str]] = None,
         filters: Optional[bool] = None,
         exclude: Optional[bool] = None,
-        operation: Optional[Dict] = None,
+        operation: Optional[_SchemaType] = None,
         methods: Optional[Sequence[str]] = None,
         versions: Optional[Sequence[str]] = None,
         examples: Optional[Sequence[OpenApiExample]] = None,
@@ -542,7 +544,7 @@ def extend_schema(
 
 
 def extend_schema_field(
-        field: Union[_SerializerType, _FieldType, OpenApiTypes, Dict],
+        field: Union[_SerializerType, _FieldType, OpenApiTypes, _SchemaType],
         component_name: Optional[str] = None
 ) -> Callable[[F], F]:
     """

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -1,7 +1,7 @@
 import json
 from collections import namedtuple
 from importlib import import_module
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Type
 
 from django.conf import settings
 from django.templatetags.static import static
@@ -14,6 +14,7 @@ from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
+from drf_spectacular.generators import SchemaGenerator
 from drf_spectacular.plumbing import get_relative_url, set_query_parameters
 from drf_spectacular.renderers import (
     OpenApiJsonRenderer, OpenApiJsonRenderer2, OpenApiYamlRenderer, OpenApiYamlRenderer2,
@@ -52,12 +53,12 @@ class SpectacularAPIView(APIView):
     ]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
-    generator_class = spectacular_settings.DEFAULT_GENERATOR_CLASS
-    serve_public = spectacular_settings.SERVE_PUBLIC
-    urlconf = spectacular_settings.SERVE_URLCONF
-    api_version = None
-    custom_settings = None
-    patterns = None
+    generator_class: Type[SchemaGenerator] = spectacular_settings.DEFAULT_GENERATOR_CLASS
+    serve_public: bool = spectacular_settings.SERVE_PUBLIC
+    urlconf: Optional[str] = spectacular_settings.SERVE_URLCONF
+    api_version: Optional[str] = None
+    custom_settings: Optional[Dict[str, Any]] = None
+    patterns: Optional[List[Any]] = None
 
     @extend_schema(**SCHEMA_KWARGS)
     def get(self, request, *args, **kwargs):
@@ -122,11 +123,11 @@ class SpectacularSwaggerView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
-    url_name = 'schema'
-    url = None
-    template_name = 'drf_spectacular/swagger_ui.html'
-    template_name_js = 'drf_spectacular/swagger_ui.js'
-    title = spectacular_settings.TITLE
+    url_name: str = 'schema'
+    url: Optional[str] = None
+    template_name: str = 'drf_spectacular/swagger_ui.html'
+    template_name_js: str = 'drf_spectacular/swagger_ui.js'
+    title: str = spectacular_settings.TITLE
 
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
@@ -192,7 +193,7 @@ class SpectacularSwaggerSplitView(SpectacularSwaggerView):
     Alternate Swagger UI implementation that separates the html request from the
     javascript request to cater to web servers with stricter CSP policies.
     """
-    url_self = None
+    url_self: Optional[str] = None
 
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
@@ -231,10 +232,10 @@ class SpectacularRedocView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
-    url_name = 'schema'
-    url = None
-    template_name = 'drf_spectacular/redoc.html'
-    title = spectacular_settings.TITLE
+    url_name: str = 'schema'
+    url: Optional[str] = None
+    template_name: str = 'drf_spectacular/redoc.html'
+    title: Optional[str] = spectacular_settings.TITLE
 
     @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@ uritemplate>=2.0.0
 PyYAML>=5.1
 jsonschema>=2.6.0
 inflection>=0.3.1
-typing-extensions; python_version < "3.8"
+typing-extensions; python_version < "3.10"

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,2 +1,3 @@
 Sphinx>=4.1.0
 sphinx_rtd_theme>=0.5.1
+typing-extensions

--- a/tests/contrib/test_drf_spectacular_sidecar.py
+++ b/tests/contrib/test_drf_spectacular_sidecar.py
@@ -34,7 +34,7 @@ def test_sidecar_shortcut_urls_are_resolved(no_warnings):
 def test_sidecar_package_urls_matching(no_warnings):
     # poor man's test to make sure the sidecar package contents match with what
     # collectstatic is going to compile. cannot be tested directly.
-    import drf_spectacular_sidecar  # type: ignore[import]
+    import drf_spectacular_sidecar  # type: ignore[import-not-found]
     module_root = os.path.dirname(inspect.getfile(drf_spectacular_sidecar))
     bundle_path = os.path.join(module_root, BUNDLE_URL)
     assert os.path.isfile(bundle_path)

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -14,7 +14,7 @@ except ImportError:
     class BaseModel:  # type: ignore
         pass
 
-    def dataclass(f):  # type: ignore
+    def dataclass(f):
         return f
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -93,7 +93,7 @@ class AllFields(models.Model):
     if DJANGO_VERSION > '3.1':
         field_nullbool = models.BooleanField(null=True)
     else:
-        field_nullbool = models.NullBooleanField()  # type: ignore
+        field_nullbool = models.NullBooleanField()
     field_time = models.TimeField()
     field_duration = models.DurationField()
     field_binary = models.BinaryField()
@@ -202,7 +202,7 @@ class AllFieldsSerializer(serializers.ModelSerializer):
     )  # type: ignore
     field_related_slug_queryset = serializers.SlugRelatedField(
         source='field_foreign', slug_field='url', queryset=Aux.objects.all()
-    )  # type: ignore
+    )
     field_related_slug_many = serializers.SlugRelatedField(
         many=True, read_only=True, source='field_m2m', slug_field='url',
     )  # type: ignore

--- a/tox.ini
+++ b/tox.ini
@@ -97,11 +97,28 @@ use_parentheses = true
 include_trailing_comma = true
 
 [mypy]
-python_version = 3.8
+python_version = 3.10
 plugins = mypy_django_plugin.main,mypy_drf_plugin.main
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
 
 [mypy.plugins.django-stubs]
 django_settings_module = "tests.settings"
+
+[mypy-drf_spectacular.*]
+strict_equality = True
+no_implicit_optional = True
+disallow_untyped_decorators = True
+disallow_subclassing_any = True
+no_implicit_reexport = True
+;check_untyped_defs = True
+;warn_return_any = True
+;disallow_incomplete_defs = True
+;disallow_any_generics = True
+;disallow_untyped_calls = True
+;disallow_untyped_defs = True
+
 
 [mypy-rest_framework.compat.*]
 ignore_missing_imports = True


### PR DESCRIPTION
Type improvements. This will fix some of the `mypy --strict` flags. Green for the following flags. Commented out flags still fail.

```bash
mypy --config-file tox.ini drf_spectacular \
--warn-unused-configs \ 
--strict-equality \
--no-implicit-optional \ 
--warn-redundant-casts \
--disallow-untyped-decorators \ 
--disallow-subclassing-any \ 
--warn-unused-ignores \ 
#--check-untyped-defs \
#--warn-return-any \
#--no-implicit-reexport \
#--disallow-incomplete-defs \
#--disallow-any-generics \
#--disallow-untyped-calls \
#--disallow-untyped-defs \
```