### PR TITLE
Add support for djangorestframework-dataclasses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Features
         - `django-filter <https://github.com/carltongibson/django-filter>`_
         - `drf-nested-routers <https://github.com/alanjds/drf-nested-routers>`_
         - `djangorestframework-recursive <https://github.com/heywbj/django-rest-framework-recursive>`_
+        - `djangorestframework-dataclasses <https://github.com/oxan/djangorestframework-dataclasses>`_
 
 
 For more information visit the `documentation <https://drf-spectacular.readthedocs.io>`_.

--- a/drf_spectacular/contrib/__init__.py
+++ b/drf_spectacular/contrib/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     'djangorestframework_camel_case',
     'rest_auth',
     'rest_polymorphic',
+    'rest_framework_dataclasses',
     'rest_framework_jwt',
     'rest_framework_simplejwt',
     'django_filters',

--- a/drf_spectacular/contrib/rest_framework_dataclasses.py
+++ b/drf_spectacular/contrib/rest_framework_dataclasses.py
@@ -1,0 +1,24 @@
+from drf_spectacular.extensions import OpenApiSerializerExtension
+from drf_spectacular.plumbing import get_doc
+from drf_spectacular.utils import Direction
+
+
+class OpenApiDataclassSerializerExtensions(OpenApiSerializerExtension):
+    target_class = "rest_framework_dataclasses.serializers.DataclassSerializer"
+    match_subclasses = True
+
+    def get_name(self):
+        """Use the dataclass name in the schema, instead of the serializer prefix (which can be just Dataclass)."""
+        return self.target.dataclass_definition.dataclass_type.__name__
+
+    def strip_library_doc(self, schema):
+        """Strip the DataclassSerializer library documentation from the schema."""
+        from rest_framework_dataclasses.serializers import DataclassSerializer
+        if 'description' in schema and schema['description'] == get_doc(DataclassSerializer):
+            del schema['description']
+        return schema
+
+    def map_serializer(self, auto_schema, direction: Direction):
+        """"Generate the schema for a DataclassSerializer."""
+        schema = auto_schema._map_serializer(self.target, direction, bypass_extensions=True)
+        return self.strip_library_doc(schema)

--- a/requirements/optionals.txt
+++ b/requirements/optionals.txt
@@ -11,3 +11,4 @@ psycopg2-binary>=2.7.3.2
 drf-nested-routers>=0.93.3
 djangorestframework-recursive>=0.1.2
 drf-spectacular-sidecar
+djangorestframework-dataclasses>=1.0.0; python_version >= '3.7'

--- a/tests/contrib/test_rest_framework_dataclasses.py
+++ b/tests/contrib/test_rest_framework_dataclasses.py
@@ -1,0 +1,51 @@
+import sys
+import typing
+
+import pytest
+from django.urls import path
+from rest_framework.decorators import api_view
+
+from drf_spectacular.utils import extend_schema
+from tests import assert_schema, generate_schema
+
+
+@pytest.mark.contrib('rest_framework_dataclasses')
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='dataclass required by package')
+def test_rest_framework_dataclasses(no_warnings):
+    from dataclasses import dataclass
+
+    from rest_framework_dataclasses.serializers import DataclassSerializer
+
+    @dataclass
+    class Person:
+        name: str
+        length: int
+
+    @dataclass
+    class Group:
+        name: str
+        leader: Person
+        members: typing.List[Person]
+
+    class GroupSerializer(DataclassSerializer):
+        class Meta:
+            dataclass = Group
+
+    @extend_schema(responses=GroupSerializer)
+    @api_view(['GET'])
+    def named(request):
+        pass  # pragma: no cover
+
+    @extend_schema(responses=DataclassSerializer(dataclass=Person))
+    @api_view(['GET'])
+    def anonymous(request):
+        pass  # pragma: no cover
+
+    urlpatterns = [
+        path('named', named),
+        path('anonymous', anonymous),
+    ]
+    assert_schema(
+        generate_schema(None, patterns=urlpatterns),
+        'tests/contrib/test_rest_framework_dataclasses.yml'
+    )

--- a/tests/contrib/test_rest_framework_dataclasses.yml
+++ b/tests/contrib/test_rest_framework_dataclasses.yml
@@ -1,0 +1,72 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /anonymous:
+    get:
+      operationId: anonymous_retrieve
+      tags:
+      - anonymous
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Person'
+          description: ''
+  /named:
+    get:
+      operationId: named_retrieve
+      tags:
+      - named
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+          description: ''
+components:
+  schemas:
+    Group:
+      type: object
+      properties:
+        name:
+          type: string
+        leader:
+          $ref: '#/components/schemas/Person'
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/Person'
+      required:
+      - leader
+      - members
+      - name
+    Person:
+      type: object
+      properties:
+        name:
+          type: string
+        length:
+          type: integer
+      required:
+      - length
+      - name
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid

--- a/tox.ini
+++ b/tox.ini
@@ -137,3 +137,6 @@ ignore_missing_imports = True
 
 [mypy-rest_framework_recursive.*]
 ignore_missing_imports = True
+
+[mypy-rest_framework_dataclasses.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Add an extension to support my [djangorestframework-dataclasses](https://github.com/oxan/djangorestframework-dataclasses) project. I've been getting a few requests for this: [#52](https://github.com/oxan/djangorestframework-dataclasses/issues/52), [#41](https://github.com/oxan/djangorestframework-dataclasses/issues/41), [#28](https://github.com/oxan/djangorestframework-dataclasses/issues/28).