### PR TITLE
Add list/pagination formatting to serializer examples

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -36,7 +36,7 @@ from drf_spectacular.plumbing import (
 )
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, OpenApiExample
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, OpenApiResponse
 
 
 class AutoSchema(ViewInspector):

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -36,10 +36,10 @@ paths:
                 items:
                   $ref: '#/components/schemas/C'
               examples:
-                SerializerCExampleRO:
+                ListSerializerCExampleRO:
                   value:
-                    field: 111
-                  summary: Serializer C Example RO
+                  - field: 111
+                  summary: List Serializer C Example RO
           description: ''
     post:
       operationId: schema_create


### PR DESCRIPTION
- Add an automatic formatting of serializer examples to list / paginated schemas, for list / paginated views.
- Adapt a test to use the list schema.