### PR TITLE
Import type information directly from the `typing` module.

### DIFF
--- a/drf_spectacular/drainage.py
+++ b/drf_spectacular/drainage.py
@@ -4,13 +4,6 @@ import sys
 from collections import defaultdict
 from typing import DefaultDict
 
-if sys.version_info >= (3, 8):
-    from typing import Final, Literal, _TypedDictMeta  # type: ignore[attr-defined] # noqa: F401
-else:
-    from typing_extensions import (  # type: ignore[attr-defined] # noqa: F401
-        Final, Literal, _TypedDictMeta,
-    )
-
 
 class GeneratorStats:
     _warn_cache: DefaultDict[str, int] = defaultdict(int)

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -14,6 +14,13 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, DefaultDict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 
+if sys.version_info >= (3, 8):
+    from typing import Literal, _TypedDictMeta  # type: ignore[attr-defined] # noqa: F401
+else:
+    from typing_extensions import (  # type: ignore[attr-defined] # noqa: F401
+        Literal, _TypedDictMeta,
+    )
+
 import inflection
 import uritemplate
 from django.apps import apps
@@ -39,7 +46,7 @@ from rest_framework.test import APIRequestFactory
 from rest_framework.utils.mediatypes import _MediaType
 from uritemplate import URITemplate
 
-from drf_spectacular.drainage import Literal, _TypedDictMeta, cache, error, warn
+from drf_spectacular.drainage import cache, error, warn
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import (
     DJANGO_PATH_CONVERTER_MAPPING, OPENAPI_TYPE_MAPPING, PYTHON_TYPE_MAPPING, OpenApiTypes,

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -131,10 +131,10 @@ class OpenApiParameter(OpenApiSchemaBase):
     For valid ``style`` choices please consult the
     `OpenAPI specification <https://swagger.io/specification/#style-values>`_.
     """
-    QUERY: Final = 'query'
-    PATH: Final = 'path'
-    HEADER: Final = 'header'
-    COOKIE: Final = 'cookie'
+    QUERY: Final[Literal['query']] = 'query'
+    PATH: Final[Literal['path']] = 'path'
+    HEADER: Final[Literal['header']] = 'header'
+    COOKIE: Final[Literal['cookie']] = 'cookie'
 
     def __init__(
             self,

--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -1,12 +1,20 @@
 import inspect
+import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Final, Literal  # type: ignore[attr-defined] # noqa: F401
+else:
+    from typing_extensions import (  # type: ignore[attr-defined] # noqa: F401
+        Final, Literal,
+    )
 
 from rest_framework.fields import Field, empty
 from rest_framework.serializers import Serializer
 from rest_framework.settings import api_settings
 
 from drf_spectacular.drainage import (
-    Final, Literal, error, get_view_method_names, isolate_view_method, set_override, warn,
+    error, get_view_method_names, isolate_view_method, set_override, warn,
 )
 from drf_spectacular.types import OpenApiTypes, _KnownPythonTypes
 
@@ -131,10 +139,10 @@ class OpenApiParameter(OpenApiSchemaBase):
     For valid ``style`` choices please consult the
     `OpenAPI specification <https://swagger.io/specification/#style-values>`_.
     """
-    QUERY: Final[Literal['query']] = 'query'
-    PATH: Final[Literal['path']] = 'path'
-    HEADER: Final[Literal['header']] = 'header'
-    COOKIE: Final[Literal['cookie']] = 'cookie'
+    QUERY: Final = 'query'
+    PATH: Final = 'path'
+    HEADER: Final = 'header'
+    COOKIE: Final = 'cookie'
 
     def __init__(
             self,


### PR DESCRIPTION
Hello, thank you for all your hard work on drf-spectacular!

At Materialize, we currently use [pyright](https://github.com/microsoft/pyright) as our static type checker. In the most recent update, we ran into an issue (https://github.com/microsoft/pyright/issues/3044) that the pyright authors are declining to fix. As a result `OpenApiParameter.QUERY`, `PATH`, etc. are not being typed correctly and fail validation. 

This PR works around the issue by importing from the `typing` module directly instead of indirectly through the `drainage` module. Is this something you'd be willing to consider?