### PR TITLE
Keep the urlpatterns in the apiview and pass it to the generator

### DIFF
--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -54,6 +54,7 @@ class SpectacularAPIView(APIView):
     urlconf = spectacular_settings.SERVE_URLCONF
     api_version = None
     custom_settings = None
+    patterns = None
 
     @extend_schema(**SCHEMA_KWARGS)
     def get(self, request, *args, **kwargs):
@@ -72,7 +73,7 @@ class SpectacularAPIView(APIView):
         # version specified as parameter to the view always takes precedence. after
         # that we try to source version through the schema view's own versioning_class.
         version = self.api_version or request.version or self._get_version_parameter(request)
-        generator = self.generator_class(urlconf=self.urlconf, api_version=version)
+        generator = self.generator_class(urlconf=self.urlconf, api_version=version, patterns=self.patterns)
         return Response(
             data=generator.get_schema(request=request, public=self.serve_public),
             headers={"Content-Disposition": f'inline; filename="{self._get_filename(request, version)}"'}


### PR DESCRIPTION
The current way to exclude an `APIView`  from a schema (or to have multuple schemas) is a bit convoluted via the preprocessing (AFAIK). The `BaseSchemaGenerator` of DRF accepts an argument `patterns` that could help simplify that. This PR simply adds an attribute to the `SpectacularAPIView` that keeps track of the urlpatterns to instrospect.

I guess spliting my api in different apps and using urlconf would work the same. But this seems easier. At the end we can have several versions and schemas per version. The patterns can be passed via the `as_view` classmethod. 

An example:
```python

routers = {
  'v1': routers.DefaultRouter(),
  'v2': routers.DefaultRouter()
}

# Register the views.

# Define urlpatterns.
urlpatterns = []
for version, router in routers.items():
  router_path = path(f'{version}/', include(router.urls))
  schema_view = SpectacularAPIView.as_view(patterns=[router_path])
  schema_path = path(f'{version}/schema/', schema_view, name=f'schema-{version}')
  urlpatterns += [router_path, schema_path]
```

I am unsure if there is an easier way to separate versions or in general having multiple schemas associated to different routers. I couldn't find anything else beyond some comments suggesting to use the preprocessing hooks. This solutions seems more consisten to DRF since it uses the already existing arguments passed to the `SchemaGenerator`, and is a very simple addition.

Let me know if there something wrong with this or if there is a recommended way of doing the separation of schemas.

Best,