### PR TITLE
Support negative numbers in pattern regex for coerced decimal fields

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -722,7 +722,7 @@ class AutoSchema(ViewInspector):
                 content = {**build_basic_type(OpenApiTypes.STR), 'format': 'decimal'}
                 if field.max_whole_digits:
                     content['pattern'] = (
-                        fr'^\d{{0,{field.max_whole_digits}}}'
+                        fr'^-?\d{{0,{field.max_whole_digits}}}'
                         fr'(?:\.\d{{0,{field.decimal_places}}})?$'
                     )
             else:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -308,7 +308,7 @@ def test_model_setup_is_valid():
         field_uuid='00000000-00000000-00000000-00000000',
         field_url='https://github.com/tfranzel/drf-spectacular',
         field_ip_generic='2001:db8::8a2e:370:7334',
-        field_decimal=Decimal('666.333'),
+        field_decimal=Decimal('-666.333'),
         field_file=None,
         field_img=None,  # TODO fill with data below
         field_date='2021-09-09',

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -244,7 +244,7 @@ components:
         field_decimal:
           type: string
           format: decimal
-          pattern: ^\d{0,3}(?:\.\d{0,3})?$
+          pattern: ^-?\d{0,3}(?:\.\d{0,3})?$
         field_file:
           type: string
           format: uri

--- a/tests/test_fields_response.json
+++ b/tests/test_fields_response.json
@@ -1,6 +1,6 @@
 {
   "id": 1,
-  "field_decimal_uncoerced": 666.333,
+  "field_decimal_uncoerced": -666.333,
   "field_method_float": 1.3456,
   "field_method_object": {
     "key": "value"
@@ -58,7 +58,7 @@
   "field_uuid": "00000000-0000-0000-0000-000000000000",
   "field_url": "https://github.com/tfranzel/drf-spectacular",
   "field_ip_generic": "2001:db8::8a2e:370:7334",
-  "field_decimal": "666.333",
+  "field_decimal": "-666.333",
   "field_file": "http://testserver/hello_p8Eotwr.txt",
   "field_img": null,
   "field_date": "2021-09-09",

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1394,7 +1394,7 @@ def test_serialization_with_decimal_values(no_warnings):
     assert schema['components']['schemas']['X']['properties']['field_coerced'] == {
         'type': 'string',
         'format': 'decimal',
-        'pattern': r'^\d{0,3}(?:\.\d{0,2})?$',
+        'pattern': r'^-?\d{0,3}(?:\.\d{0,2})?$',
     }
 
     schema_yml = OpenApiYamlRenderer().render(schema, renderer_context={})


### PR DESCRIPTION
The pattern for coerced decimal fields looks like `^\d{0,3}(?:\.\d{0,3})?$` which doesn't validate negative decimals (which start with `-`). 

This pull request updates the regex to allow an optional minus sign at the beginning of the string.