### PR TITLE
Add swagger plugin settings

### DIFF
--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -65,6 +65,7 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SWAGGER_UI_SETTINGS': {
         'deepLinking': True,
     },
+    "SWAGGER_UI_PLUGINS": [],
     # Initialize SwaggerUI with additional OAuth2 configuration.
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
     'SWAGGER_UI_OAUTH2_CONFIG': {},

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -15,6 +15,9 @@
   <body>
     <div id="swagger-ui"></div>
     <script src="{{ dist }}/swagger-ui-bundle.js"></script>
+{% for plugin in plugins %}
+    <script src="{{ plugin.source }}"></script>
+{%  endfor %}
     <script src="{{ dist }}/swagger-ui-standalone-preset.js"></script>
     {% if script_url %}
     <script src="{{ script_url }}"></script>

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.js
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.js
@@ -3,7 +3,11 @@
 const swaggerSettings = {{ settings|safe }};
 const schemaAuthNames = {{ schema_auth_names|safe }};
 let schemaAuthFailed = false;
-const plugins = [];
+const plugins = [
+{% for plugin in plugins %}
+  {{ plugin.name }},
+{%  endfor %}
+];
 
 const reloadSchemaOnAuthChange = () => {
   return {

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -124,6 +124,7 @@ class SpectacularSwaggerView(APIView):
                 'favicon_href': self._swagger_ui_favicon(),
                 'schema_url': self._get_schema_url(request),
                 'settings': self._dump(spectacular_settings.SWAGGER_UI_SETTINGS),
+                'plugins': spectacular_settings.SWAGGER_UI_PLUGINS,
                 'oauth2_config': self._dump(spectacular_settings.SWAGGER_UI_OAUTH2_CONFIG),
                 'template_name_js': self.template_name_js,
                 'csrf_header_name': self._get_csrf_header_name(),

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -128,6 +128,18 @@ def test_spectacular_swagger_ui_alternate(no_warnings):
 
 
 @mock.patch(
+    'drf_spectacular.settings.spectacular_settings.SWAGGER_UI_PLUGINS',
+    [{"name": "name1", "source": "source1"}, {"name": "name2", "source": "source2"}]
+)
+@pytest.mark.urls(__name__)
+def test_spectacular_swagger_plugins(no_warnings):
+    response = APIClient().get('/api/v2/schema/swagger-ui/')
+    assert response.status_code == 200
+    assert b'const plugins = [\n\n  name1,\n\n  name2,\n\n];' in response.content
+    assert b'<script src="source1"></script>\n\n    <script src="source2"></script>' in response.content
+
+
+@mock.patch(
     'drf_spectacular.settings.spectacular_settings.SWAGGER_UI_SETTINGS',
     '{"deepLinking": true}'
 )


### PR DESCRIPTION
I wanted to add some plugin to swagger but suddenly it came up it's impossible to make it work without writing custom template, of course as far as I was able to test.

I followed [instructions](https://github.com/tfranzel/drf-spectacular/blob/f50bc104967118a53e1d4b63428a445e0b6f1a75/drf_spectacular/settings.py#L63) and they solve problem of JS object, although I had to somehow add source of that plugin.
```python
SPECTACULAR_SETTINGS = {
    "SWAGGER_UI_SETTINGS":  "plugins: [ExamplePlugin]"
}
```

---

My changes bring new setting `SWAGGER_UI_PLUGINS` which contains list of plugins (each described by dictionary) that you want to put in generated swagger.
All `source`s will be put in html file in order to download scripts and all `name`s will be put in JS code in order to use them.

example as follow:
```python
SPECTACULAR_SETTINGS = {
    "SWAGGER_UI_PLUGINS": [
        {
            "name": "ExamplePlugin",
            "source": "https://test.com/example-plugin-source"
        }
    ]
}
```

I guess you guys will find something to change so I'm open to suggestions ; )