### PR TITLE
Added `@cache` to `detype_pattern()`.

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -891,7 +891,7 @@ def modify_for_versioning(patterns, method, path, view, requested_version):
     elif issubclass(view.versioning_class, versioning.NamespaceVersioning):
         try:
             view.request.resolver_match = get_resolver(
-                urlconf=tuple(detype_pattern(p) for p in patterns)
+                urlconf=detype_patterns(tuple(patterns)),
             ).resolve(path)
         except Resolver404:
             error(f"namespace versioning path resolution failed for {path}. Path will be ignored.")
@@ -974,6 +974,12 @@ def analyze_named_regex_pattern(path):
         i += ff
     assert not stack
     return result
+
+
+@cache
+def detype_patterns(patterns):
+    """Cache detyped patterns due to the expensive nature of rebuilding URLResolver."""
+    return tuple(detype_pattern(pattern) for pattern in patterns)
 
 
 def detype_pattern(pattern):


### PR DESCRIPTION
I've had a report that our schema takes a long time to generate - up to 7 seconds in some cases.

On performing some basic profiling, I noticed a very large number of calls to `detype_pattern()`. We have a large number of endpoints which make use of similar patterns and, because of its recursive nature, it seems that `detype_pattern()` is often called with the same value.

To remedy this, I quickly tried slapping the `@cache` decorator on it to see what would happen. I received the same output before and after and noticed a massive speed-up.

Using the following commands for convenience:

```
$ time ./manage.py spectacular --format openapi-json
$ python -m cProfile -o profile ./manage.py spectacular --format openapi-json
```

I extracted the following details:

```
# Before

real    0m7.516s
user    0m7.542s
sys     0m1.679s

         15573285 function calls (14804796 primitive calls) in 7.792 seconds

   Ordered by: internal time
   List reduced from 22851 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
549318/2583    1.010    0.000    4.516    0.002 /usr/local/lib/python3.9/site-packages/drf_spectacular/plumbing.py:974(detype_pattern)
   224105    0.644    0.000    0.645    0.000 /usr/local/lib/python3.9/re.py:325(_subx)
    51660    0.545    0.000    0.617    0.000 /usr/local/lib/python3.9/site-packages/drf_spectacular/plumbing.py:929(analyze_named_regex_pattern)
  2532964    0.475    0.000    0.481    0.000 {built-in method builtins.isinstance}
   229623    0.437    0.000    0.887    0.000 /usr/local/lib/python3.9/site-packages/django/urls/resolvers.py:201(_route_to_regex)
     3724    0.262    0.000    0.262    0.000 {built-in method marshal.loads}
   226624    0.237    0.000    0.998    0.000 {method 'sub' of 're.Pattern' objects}
11606/10815    0.183    0.000    0.688    0.000 {built-in method builtins.__build_class__}
   243937    0.175    0.000    0.175    0.000 /usr/local/lib/python3.9/site-packages/django/urls/resolvers.py:319(__init__)
   223777    0.144    0.000    1.017    0.000 /usr/local/lib/python3.9/site-packages/django/urls/resolvers.py:244(__init__)

# After

real    0m2.626s
user    0m2.670s
sys     0m1.624s

         6191512 function calls (5999528 primitive calls) in 3.296 seconds

   Ordered by: internal time
   List reduced from 22840 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3725    0.262    0.000    0.262    0.000 {built-in method marshal.loads}
11606/10815    0.158    0.000    0.691    0.000 {built-in method builtins.__build_class__}
     2411    0.086    0.000    0.091    0.000 /usr/local/lib/python3.9/site-packages/django/urls/resolvers.py:201(_route_to_regex)
6592/1397    0.057    0.000    0.155    0.000 /usr/local/lib/python3.9/sre_parse.py:493(_parse)
   145/98    0.056    0.000    0.081    0.001 {built-in method _imp.exec_dynamic}
     6317    0.050    0.000    0.056    0.000 <frozen importlib._bootstrap>:166(_get_module_lock)
    23652    0.047    0.000    0.047    0.000 {built-in method posix.stat}
   539853    0.043    0.000    0.049    0.000 {built-in method builtins.isinstance}
     4748    0.038    0.000    0.038    0.000 {method 'read' of '_io.BufferedReader' objects}
       34    0.036    0.001    0.036    0.001 {built-in method posix.read}
```

Considering this is running from the command line which includes the overhead of starting up Python and loading Django stuff, I thought I'd see how much start-up overhead could possibly be discounted from the above figures which would have no effect on a standard request:

```
$ time ./manage.py spectacular --help
$ python -m cProfile -o profile ./manage.py spectacular --help
```

```
real    0m1.993s
user    0m2.073s
sys     0m1.638s

         3783909 function calls (3693665 primitive calls) in 2.300 seconds

   Ordered by: internal time
   List reduced from 19721 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3201    0.242    0.000    0.242    0.000 {built-in method marshal.loads}
10395/9755    0.145    0.000    0.616    0.000 {built-in method builtins.__build_class__}
   145/98    0.056    0.000    0.081    0.001 {built-in method _imp.exec_dynamic}
     5315    0.050    0.000    0.055    0.000 <frozen importlib._bootstrap>:166(_get_module_lock)
 5491/831    0.042    0.000    0.116    0.000 /usr/local/lib/python3.9/sre_parse.py:493(_parse)
    20069    0.040    0.000    0.040    0.000 {built-in method posix.stat}
     4223    0.039    0.000    0.039    0.000 {method 'read' of '_io.BufferedReader' objects}
       34    0.035    0.001    0.035    0.001 {built-in method posix.read}
     1889    0.031    0.000    0.033    0.000 {built-in method builtins.eval}
      438    0.028    0.000    0.052    0.000 /usr/local/lib/python3.9/site-packages/pytz/tzfile.py:24(build_tzinfo)
```

So less the start up time of 2s, this looks like an actual request via HTTP would have an improvement something along the lines of ~5.5s → ~0.5s.

Given the nature of this, I'm wondering whether this might also partially address the issue raised in #597.