### PR TITLE
Use Django management CommandError to eliminate the traceback on error

### DIFF
--- a/drf_spectacular/management/commands/spectacular.py
+++ b/drf_spectacular/management/commands/spectacular.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.utils import translation
 from django.utils.module_loading import import_string
 
@@ -8,6 +8,10 @@ from drf_spectacular.drainage import GENERATOR_STATS
 from drf_spectacular.renderers import OpenApiJsonRenderer, OpenApiYamlRenderer
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.validation import validate_schema
+
+
+class SchemaValidationError(CommandError):
+    pass
 
 
 class Command(BaseCommand):
@@ -52,7 +56,7 @@ class Command(BaseCommand):
         GENERATOR_STATS.emit_summary()
 
         if options['fail_on_warn'] and GENERATOR_STATS:
-            raise RuntimeError('Failing as requested due to warnings')
+            raise SchemaValidationError('Failing as requested due to warnings')
         if options['validate']:
             validate_schema(schema)
 


### PR DESCRIPTION
Instead of the long traceback, the error now looks like:

    Schema generation summary:
    Warnings: 4 (1 unique)
    Errors:   0 (0 unique)

    SchemaValidationError: Failing as requested due to warnings