### PR TITLE
If available, use docstrings from properties for field descriptions 

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -50,6 +50,9 @@ class SubObject:
 
     @property
     def calculated(self) -> int:
+        """
+        My calculated property
+        """
         return self._instance.field_int
 
     @property

--- a/tests/test_fields.yml
+++ b/tests/test_fields.yml
@@ -178,33 +178,40 @@ components:
           additionalProperties: {}
         field_sub_object_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
         field_sub_object_nested_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
         field_sub_object_model_int:
           type: integer
           readOnly: true
         field_sub_object_cached_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
         field_sub_object_cached_nested_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
         field_sub_object_cached_model_int:
           type: integer
           readOnly: true
         field_sub_object_py_cached_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
         field_sub_object_py_cached_nested_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
         field_sub_object_py_cached_model_int:
           type: integer
           readOnly: true
         field_optional_sub_object_calculated:
           type: integer
+          description: My calculated property
           readOnly: true
           nullable: true
         field_sub_object_optional_int:


### PR DESCRIPTION
Should be self-explanatory from the tests. This can be a big help in transferring knowledge from docstrings into the schema for frontend developers.

There was one issue with `partial` that the test suite found, I just added a special case top deal with that. Otherwise you get things like `description: partial(func, *args, **keywords) - new function with partial application of the given arguments and keywords` which is unhelpful noise.
