### PR TITLE
Include context with request when instantiating serializers

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1072,20 +1072,21 @@ class AutoSchema(ViewInspector):
 
     def _get_serializer(self):
         view = self.view
+        context = {'request': view.request}
         try:
             if isinstance(view, GenericAPIView):
                 # try to circumvent queryset issues with calling get_serializer. if view has NOT
                 # overridden get_serializer, its safe to use get_serializer_class.
                 if view.__class__.get_serializer == GenericAPIView.get_serializer:
-                    return view.get_serializer_class()()
-                return view.get_serializer()
+                    return view.get_serializer_class()(context=context)
+                return view.get_serializer(context=context)
             elif isinstance(view, APIView):
                 # APIView does not implement the required interface, but be lenient and make
                 # good guesses before giving up and emitting a warning.
                 if callable(getattr(view, 'get_serializer', None)):
-                    return view.get_serializer()
+                    return view.get_serializer(context=context)
                 elif callable(getattr(view, 'get_serializer_class', None)):
-                    return view.get_serializer_class()()
+                    return view.get_serializer_class()(context=context)
                 elif hasattr(view, 'serializer_class'):
                     return view.serializer_class
                 else:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -275,8 +275,9 @@ def test_serializer_retrieval_from_view(no_warnings):
     class X1Viewset(mixins.ListModelMixin, viewsets.GenericViewSet):
         serializer_class = UnusedSerializer
 
-        def get_serializer(self):
-            return XSerializer()
+        def get_serializer(self, *args, **kwargs):
+            assert 'request' in kwargs['context']
+            return XSerializer(*args, **kwargs)
 
     class X2Viewset(mixins.ListModelMixin, viewsets.GenericViewSet):
         def get_serializer_class(self):


### PR DESCRIPTION
We use a versioning system where we can have different versions of individual serializers, but override `Serializer.get_fields()` to inspect the version in `self.context['request']` to determine which sub-serializers to use. In order for this to work, we need to have access to the context/request on the instantiated serializer.

I added one basic test covering one of the branches and am happy to add some more depending on your preferences. I'm not sure how high of a level you'd like something like this tested; for example, I could make something in `test_versioning.py` testing all branches, but would require additional test `.yml` files to maintain.