### PR TITLE
Add examples camelization note to settings.py

### DIFF
--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -118,6 +118,9 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'GET_MOCK_REQUEST': 'drf_spectacular.plumbing.build_mock_request',
 
     # Camelize names like operationId and path parameter names
+    # Camelization of example JSON responses and Schema requires the addition of 
+    # 'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields'
+    # to POSTPROCESSING_HOOKS
     'CAMELIZE_NAMES': False,
 
     # Determines if and how free-form 'additionalProperties' should be emitted in the schema. Some


### PR DESCRIPTION
Camelization of example JSON responses and Schema requires the addition of 'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields' to POSTPROCESSING_HOOKS

Related to Issue #355 