### PR TITLE
django-filter: Enable type extraction fallback for MultipleChoiceFilter

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -117,7 +117,7 @@ class DjangoFilterExtension(OpenApiFilterExtension):
                 schema = build_basic_type(OpenApiTypes.NUMBER)  # TODO may be improved
             else:
                 schema = build_basic_type(OpenApiTypes.NUMBER)
-        elif isinstance(filter_field, filters.ChoiceFilter):
+        elif isinstance(filter_field, (filters.ChoiceFilter, filters.MultipleChoiceFilter)):
             try:
                 schema = self._get_schema_from_model_field(auto_schema, filter_field, model)
             except Exception:

--- a/tests/contrib/test_django_filters.py
+++ b/tests/contrib/test_django_filters.py
@@ -128,6 +128,10 @@ class ProductFilter(FilterSet):
         method="filter_method_untyped",
         choices=[(1, 'one')],
     )
+    untyped_multiple_choice_field_method_with_explicit_choices = MultipleChoiceFilter(
+        method="filter_method_multi_untyped",
+        choices=[(1, 'one')],
+    )
 
     class Meta:
         model = Product
@@ -141,6 +145,9 @@ class ProductFilter(FilterSet):
 
     def filter_method_untyped(self, queryset, name, value):
         return queryset.filter(id=int(value))  # pragma: no cover
+
+    def filter_method_multi_untyped(self, queryset, name, value):
+        return queryset.filter(id__in=int(value))  # pragma: no cover
 
     # email makes no sense here. it's just to test decoration
     @extend_schema_field(OpenApiTypes.EMAIL)

--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -187,6 +187,16 @@ paths:
           type: integer
           enum:
           - 1
+      - in: query
+        name: untyped_multiple_choice_field_method_with_explicit_choices
+        schema:
+          type: array
+          items:
+            type: integer
+            enum:
+            - 1
+        explode: true
+        style: form
       tags:
       - products
       security:


### PR DESCRIPTION
Follow up to #690, https://github.com/tfranzel/drf-spectacular/commit/6f5bd1688182829204bb61db6a9d7903fdaf0bbe and https://github.com/tfranzel/drf-spectacular/issues/690#issuecomment-1118518769.
Enables the implemented fix for `MultipleChoiceFilter` as well.