### PR TITLE
Reference enums in path parameters

### DIFF
--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -20,10 +20,7 @@ paths:
       - in: query
         name: category
         schema:
-          type: string
-          enum:
-          - A
-          - B
+          $ref: '#/components/schemas/CategoryEnum'
         description: some category description
       - in: query
         name: custom_filter
@@ -34,10 +31,7 @@ paths:
         schema:
           type: array
           items:
-            type: string
-            enum:
-            - A
-            - B
+            $ref: '#/components/schemas/CategoryEnum'
         description: Multiple values may be separated by commas.
         explode: false
         style: form
@@ -51,10 +45,7 @@ paths:
         schema:
           type: array
           items:
-            type: string
-            enum:
-            - A
-            - B
+            $ref: '#/components/schemas/CategoryEnum'
         description: Multiple values may be separated by commas.
         explode: false
         style: form
@@ -93,10 +84,7 @@ paths:
         schema:
           type: array
           items:
-            type: string
-            enum:
-            - A
-            - B
+            $ref: '#/components/schemas/CategoryEnum'
         description: some category description
         explode: true
         style: form
@@ -111,10 +99,7 @@ paths:
       - in: query
         name: model_single_cat
         schema:
-          type: string
-          enum:
-          - A
-          - B
+          $ref: '#/components/schemas/CategoryEnum'
         description: some category description
       - in: query
         name: number_id


### PR DESCRIPTION
We're just switching to drf-spectacular from a heavily patched 'vanilla' drf schema generator, and it's great to see so many of the issues we'd fixed already fixed here.

This PR ensures that enums in paths also use the same reference as enums in schemas.