### PR TITLE
Do not set `enum` in schema when extend_schema_field is used on django-filter `[Multiple]ChoiceFilter`

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -85,8 +85,10 @@ class DjangoFilterExtension(OpenApiFilterExtension):
         filter_method = self._get_filter_method(filterset_class, filter_field)
         filter_method_hint = self._get_filter_method_hint(filter_method)
         filter_choices = self._get_explicit_filter_choices(filter_field)
+        schema_from_override = False
 
         if has_override(filter_field, 'field') or has_override(filter_method, 'field'):
+            schema_from_override = True
             annotation = (
                 get_override(filter_field, 'field') or get_override(filter_method, 'field')
             )
@@ -148,7 +150,7 @@ class DjangoFilterExtension(OpenApiFilterExtension):
         # enrich schema with additional info from filter_field
         enum = schema.pop('enum', None)
         # explicit filter choices may disable enum retrieved from model
-        if filter_choices is not None:
+        if not schema_from_override and filter_choices is not None:
             enum = filter_choices
         if enum:
             schema['enum'] = sorted(enum, key=str)

--- a/tests/contrib/test_django_filters.py
+++ b/tests/contrib/test_django_filters.py
@@ -123,6 +123,8 @@ class ProductFilter(FilterSet):
 
     cat_callable = ChoiceFilter(field_name="category", choices=get_choices)
 
+    choice_field_enum_override = extend_schema_field(OpenApiTypes.STR)(ChoiceFilter(choices=(('A', 'aaa'), )))
+
     # will guess type from choices as a last resort
     untyped_choice_field_method_with_explicit_choices = ChoiceFilter(
         method="filter_method_untyped",

--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -26,6 +26,10 @@ paths:
           - B
         description: some category description
       - in: query
+        name: choice_field_enum_override
+        schema:
+          type: string
+      - in: query
         name: custom_filter
         schema:
           type: boolean


### PR DESCRIPTION
Fixes #735 