### PR TITLE
`django-rest-framework-gis` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.setup.python-version }}
+      - name: Install system dependencies
+        run: sudo apt-get install -y gdal-bin libsqlite3-mod-spatialite
       - name: Install tox
         run: pip install tox
       - name: Run Tox

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Features
         - `drf-nested-routers <https://github.com/alanjds/drf-nested-routers>`_
         - `djangorestframework-recursive <https://github.com/heywbj/django-rest-framework-recursive>`_
         - `djangorestframework-dataclasses <https://github.com/oxan/djangorestframework-dataclasses>`_
+        - `django-rest-framework-gis <https://github.com/openwisp/django-rest-framework-gis>`_
 
 
 For more information visit the `documentation <https://drf-spectacular.readthedocs.io/>`_.

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -229,6 +229,10 @@ This is one of the more involved extension mechanisms. *drf-spectacular* uses th
 The usage of this extension is rarely necessary because most custom ``Serializer`` classes stay very
 close to the default behaviour.
 
+In case your ``Serializer`` makes use of a custom ``ListSerializer`` (i.e. a custom ``to_representation()``),
+you can write a dedicated extensions for that. This is usually the case when ``many=True`` does not result
+in a plain list, but rather in augmented object with additional fields (e.g. envelopes).
+
 Declare custom/library filters with :py:class:`OpenApiFilterExtension <drf_spectacular.extensions.OpenApiFilterExtension>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/drf_spectacular/contrib/__init__.py
+++ b/drf_spectacular/contrib/__init__.py
@@ -8,4 +8,5 @@ __all__ = [
     'rest_framework_simplejwt',
     'django_filters',
     'rest_framework_recursive',
+    'rest_framework_gis',
 ]

--- a/drf_spectacular/contrib/rest_framework_gis.py
+++ b/drf_spectacular/contrib/rest_framework_gis.py
@@ -1,0 +1,216 @@
+from django.contrib.gis.db import models
+from rest_framework.utils.model_meta import get_field_info
+
+from drf_spectacular.drainage import warn
+from drf_spectacular.extensions import OpenApiSerializerExtension, OpenApiSerializerFieldExtension
+from drf_spectacular.plumbing import ResolvedComponent, build_array_type, build_object_type, get_doc
+
+
+def build_point_schema():
+    return {
+        "type": "array",
+        "items": {"type": "number", "format": "float"},
+        "example": [12.9721, 77.5933],
+        "minItems": 2,
+        "maxItems": 3,
+    }
+
+
+def build_linestring_schema():
+    return {
+        "type": "array",
+        "items": build_point_schema(),
+        "example": [[22.4707, 70.0577], [12.9721, 77.5933]],
+        "minItems": 2,
+    }
+
+
+def build_polygon_schema():
+    return {
+        "type": "array",
+        "items": {**build_linestring_schema(), "minItems": 4},
+        "example": [
+            [
+                [0.0, 0.0],
+                [0.0, 50.0],
+                [50.0, 50.0],
+                [50.0, 0.0],
+                [0.0, 0.0],
+            ],
+        ]
+    }
+
+
+def build_geo_container_schema(name, coords):
+    return build_object_type(
+        properties={
+            "type": {"type": "string", "enum": [name]},
+            "coordinates": coords,
+        }
+    )
+
+
+def build_point_geo_schema():
+    return build_geo_container_schema("Point", build_point_schema())
+
+
+def build_linestring_geo_schema():
+    return build_geo_container_schema("LineString", build_linestring_schema())
+
+
+def build_polygon_geo_schema():
+    return build_geo_container_schema("Polygon", build_polygon_schema())
+
+
+def build_geometry_geo_schema():
+    return {
+        'oneOf': [
+            build_point_geo_schema(),
+            build_linestring_geo_schema(),
+            build_polygon_geo_schema(),
+        ]
+    }
+
+
+def build_bbox_schema():
+    return {
+        "type": "array",
+        "items": {"type": "number"},
+        "minItems": 4,
+        "maxItems": 4,
+        "example": [12.9721, 77.5933, 12.9721, 77.5933],
+    }
+
+
+def build_geo_schema(model_field):
+    if isinstance(model_field, models.PointField):
+        return build_point_geo_schema()
+    elif isinstance(model_field, models.LineStringField):
+        return build_linestring_geo_schema()
+    elif isinstance(model_field, models.PolygonField):
+        return build_polygon_geo_schema()
+    elif isinstance(model_field, models.MultiPointField):
+        return build_geo_container_schema(
+            "MultiPoint", build_array_type(build_point_schema())
+        )
+    elif isinstance(model_field, models.MultiLineStringField):
+        return build_geo_container_schema(
+            "MultiLineString", build_array_type(build_linestring_schema())
+        )
+    elif isinstance(model_field, models.MultiPolygonField):
+        return build_geo_container_schema(
+            "MultiPolygon", build_array_type(build_polygon_schema())
+        )
+    elif isinstance(model_field, models.GeometryCollectionField):
+        return build_geo_container_schema(
+            "GeometryCollection", build_array_type(build_geometry_geo_schema())
+        )
+    elif isinstance(model_field, models.GeometryField):
+        return build_geometry_geo_schema()
+    else:
+        warn("Encountered unknown GIS geometry field")
+        return {}
+
+
+def map_geo_field(serializer, geo_field_name):
+    from rest_framework_gis.fields import GeometrySerializerMethodField
+
+    field = serializer.fields[geo_field_name]
+    if isinstance(field, GeometrySerializerMethodField):
+        warn("Geometry generation for GeometrySerializerMethodField is not supported.")
+        return {}
+    model_field = get_field_info(serializer.Meta.model).fields[geo_field_name]
+    return build_geo_schema(model_field)
+
+
+def _inject_enum_collision_fix(collection):
+    from drf_spectacular.settings import spectacular_settings
+    if not collection and 'GisFeatureEnum' not in spectacular_settings.ENUM_NAME_OVERRIDES:
+        spectacular_settings.ENUM_NAME_OVERRIDES['GisFeatureEnum'] = ('Feature',)
+    if collection and 'GisFeatureCollectionEnum' not in spectacular_settings.ENUM_NAME_OVERRIDES:
+        spectacular_settings.ENUM_NAME_OVERRIDES['GisFeatureCollectionEnum'] = ('FeatureCollection',)
+
+
+class GeoFeatureModelSerializerExtension(OpenApiSerializerExtension):
+    target_class = 'rest_framework_gis.serializers.GeoFeatureModelSerializer'
+    match_subclasses = True
+
+    def map_serializer(self, auto_schema, direction):
+        _inject_enum_collision_fix(collection=False)
+
+        base_schema = auto_schema._map_serializer(self.target, direction, bypass_extensions=True)
+        return self.map_geo_feature_model_serializer(self.target, base_schema)
+
+    def map_geo_feature_model_serializer(self, serializer, base_schema):
+        from rest_framework_gis.serializers import GeoFeatureModelSerializer
+
+        geo_properties = {
+            "type": {"type": "string", "enum": ["Feature"]}
+        }
+        if serializer.Meta.id_field:
+            geo_properties["id"] = base_schema["properties"].pop(serializer.Meta.id_field)
+
+        geo_properties["geometry"] = map_geo_field(serializer, serializer.Meta.geo_field)
+        base_schema["properties"].pop(serializer.Meta.geo_field)
+
+        if serializer.Meta.auto_bbox or serializer.Meta.bbox_geo_field:
+            geo_properties["bbox"] = build_bbox_schema()
+            base_schema["properties"].pop(serializer.Meta.bbox_geo_field, None)
+
+        # only expose if description comes from the user
+        description = base_schema.pop('description', None)
+        if description == get_doc(GeoFeatureModelSerializer):
+            description = None
+
+        # ignore this aspect for now
+        base_schema.pop('required', None)
+
+        # nest remaining fields under property "properties"
+        geo_properties["properties"] = base_schema
+
+        return build_object_type(
+            properties=geo_properties,
+            description=description,
+        )
+
+
+class GeoFeatureModelListSerializerExtension(OpenApiSerializerExtension):
+    target_class = 'rest_framework_gis.serializers.GeoFeatureModelListSerializer'
+
+    def map_serializer(self, auto_schema, direction):
+        _inject_enum_collision_fix(collection=True)
+
+        # build/retrieve feature component generated by GeoFeatureModelSerializerExtension.
+        # wrap the ref in the special list structure and build another component based on that.
+        feature_component = auto_schema.resolve_serializer(self.target.child, direction)
+        collection_schema = build_object_type(
+            properties={
+                "type": {"type": "string", "enum": ["FeatureCollection"]},
+                "features": build_array_type(feature_component.ref)
+            }
+        )
+        list_component = ResolvedComponent(
+            name=f'{feature_component.name}List',
+            type=ResolvedComponent.SCHEMA,
+            object=self.target.child,
+            schema=collection_schema
+        )
+        auto_schema.registry.register_on_missing(list_component)
+        return list_component.ref
+
+
+class GeometryFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'rest_framework_gis.fields.GeometryField'
+    match_subclasses = True
+
+    def map_serializer_field(self, auto_schema, direction):
+        # running this extension for GeoFeatureModelSerializer's geo_field is superfluous
+        # as above extension already handles that individually. We run it anyway because
+        # robustly checking the proper condition is harder.
+        try:
+            model = self.target.parent.Meta.model
+            model_field = get_field_info(model).fields[self.target.source]
+            return build_geo_schema(model_field)
+        except:  # noqa: E722
+            warn(f'Encountered an issue resolving field {self.target}. defaulting to generic object.')
+            return {}

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -95,6 +95,18 @@ def is_list_serializer(obj) -> bool:
     return isinstance(force_instance(obj), serializers.ListSerializer)
 
 
+def get_list_serializer(obj):
+    return force_instance(obj) if is_list_serializer(obj) else get_class(obj)(many=True)
+
+
+def is_list_serializer_customized(obj) -> bool:
+    return (
+        is_serializer(obj)
+        and get_class(get_list_serializer(obj)).to_representation  # type: ignore
+        is not serializers.ListSerializer.to_representation
+    )
+
+
 def is_basic_serializer(obj) -> bool:
     return is_serializer(obj) and not is_list_serializer(obj)
 

--- a/requirements/optionals.txt
+++ b/requirements/optionals.txt
@@ -12,3 +12,4 @@ drf-nested-routers>=0.93.3
 djangorestframework-recursive>=0.1.2
 drf-spectacular-sidecar
 djangorestframework-dataclasses>=1.0.0; python_version >= '3.7'
+djangorestframework-gis>=1.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def pytest_configure(config):
         'allauth.account',
         'oauth2_provider',
         'django_filters',
+        'rest_framework_gis',
         # this is not strictly required and when added django-polymorphic
         # currently breaks the whole Django/DRF upstream testing.
         # 'polymorphic',

--- a/tests/contrib/test_rest_framework_gis.py
+++ b/tests/contrib/test_rest_framework_gis.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+import pytest
+from django.db import models
+from rest_framework import __version__ as DRF_VERSION  # type: ignore[attr-defined]
+from rest_framework import mixins, routers, serializers, viewsets
+
+from drf_spectacular.utils import extend_schema_serializer
+from tests import assert_schema, generate_schema
+
+
+@pytest.mark.contrib('rest_framework_gis')
+@pytest.mark.skipif(DRF_VERSION < '3.12', reason='DRF pagination schema broken')
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {})
+def test_rest_framework_gis(no_warnings, clear_caches):
+    from django.contrib.gis.db.models import (
+        GeometryCollectionField, GeometryField, LineStringField, MultiLineStringField,
+        MultiPointField, MultiPolygonField, PointField, PolygonField,
+    )
+    from rest_framework_gis.pagination import GeoJsonPagination
+    from rest_framework_gis.serializers import GeoFeatureModelSerializer
+
+    class GeoModel(models.Model):
+        field_random1 = models.CharField(max_length=32)
+        field_random2 = models.IntegerField()
+        field_gis_plain = PointField()
+
+        field_polygon = PolygonField()
+        field_point = PointField()
+        field_linestring = LineStringField()
+        field_geometry = GeometryField()
+        field_multipolygon = MultiPolygonField()
+        field_multipoint = MultiPointField()
+        field_multilinestring = MultiLineStringField()
+        field_geometrycollection = GeometryCollectionField()
+
+    router = routers.SimpleRouter()
+
+    # all GIS fields as GeoJSON in singular and list form
+    fields = [
+        'Point', 'Polygon', 'Linestring', 'Geometry',
+        'Multipoint', 'Multipolygon', 'Multilinestring', 'Geometrycollection'
+    ]
+    for name in fields:
+        @extend_schema_serializer(component_name=name)
+        class XSerializer(GeoFeatureModelSerializer):
+            class Meta:
+                model = GeoModel
+                geo_field = f'field_{name.lower()}'
+                auto_bbox = name == 'Polygon'
+                fields = ['id', 'field_random1', 'field_random2', 'field_gis_plain']
+
+        class XViewset(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+            serializer_class = XSerializer
+            queryset = GeoModel.objects.none()
+
+        router.register(name.lower(), XViewset, basename=name)
+
+    # plain serializer with GIS fields but without restructured container object
+    class PlainSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = GeoModel
+            fields = ['id', 'field_random1', 'field_random2', 'field_gis_plain']
+
+    class PlainViewset(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+        serializer_class = PlainSerializer
+        queryset = GeoModel.objects.none()
+
+    router.register('plain', PlainViewset, basename='plain')
+
+    # GIS specific pagination
+    class PlainViewset(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+        serializer_class = PlainSerializer
+        queryset = GeoModel.objects.none()
+        pagination_class = GeoJsonPagination
+
+    router.register('paginated', PlainViewset, basename='paginated')
+
+    assert_schema(
+        generate_schema(None, patterns=router.urls),
+        'tests/contrib/test_rest_framework_gis.yml'
+    )

--- a/tests/contrib/test_rest_framework_gis.yml
+++ b/tests/contrib/test_rest_framework_gis.yml
@@ -1,0 +1,1163 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /geometry/:
+    get:
+      operationId: geometry_list
+      tags:
+      - geometry
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeometryList'
+          description: ''
+  /geometry/{id}/:
+    get:
+      operationId: geometry_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - geometry
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Geometry'
+          description: ''
+  /geometrycollection/:
+    get:
+      operationId: geometrycollection_list
+      tags:
+      - geometrycollection
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeometrycollectionList'
+          description: ''
+  /geometrycollection/{id}/:
+    get:
+      operationId: geometrycollection_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - geometrycollection
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Geometrycollection'
+          description: ''
+  /linestring/:
+    get:
+      operationId: linestring_list
+      tags:
+      - linestring
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LinestringList'
+          description: ''
+  /linestring/{id}/:
+    get:
+      operationId: linestring_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - linestring
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Linestring'
+          description: ''
+  /multilinestring/:
+    get:
+      operationId: multilinestring_list
+      tags:
+      - multilinestring
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultilinestringList'
+          description: ''
+  /multilinestring/{id}/:
+    get:
+      operationId: multilinestring_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - multilinestring
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Multilinestring'
+          description: ''
+  /multipoint/:
+    get:
+      operationId: multipoint_list
+      tags:
+      - multipoint
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultipointList'
+          description: ''
+  /multipoint/{id}/:
+    get:
+      operationId: multipoint_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - multipoint
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Multipoint'
+          description: ''
+  /multipolygon/:
+    get:
+      operationId: multipolygon_list
+      tags:
+      - multipolygon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultipolygonList'
+          description: ''
+  /multipolygon/{id}/:
+    get:
+      operationId: multipolygon_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - multipolygon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Multipolygon'
+          description: ''
+  /paginated/:
+    get:
+      operationId: paginated_list
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - paginated
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedPlainList'
+          description: ''
+  /paginated/{id}/:
+    get:
+      operationId: paginated_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - paginated
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plain'
+          description: ''
+  /plain/:
+    get:
+      operationId: plain_list
+      tags:
+      - plain
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Plain'
+          description: ''
+  /plain/{id}/:
+    get:
+      operationId: plain_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - plain
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plain'
+          description: ''
+  /point/:
+    get:
+      operationId: point_list
+      tags:
+      - point
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PointList'
+          description: ''
+  /point/{id}/:
+    get:
+      operationId: point_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - point
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Point'
+          description: ''
+  /polygon/:
+    get:
+      operationId: polygon_list
+      tags:
+      - polygon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolygonList'
+          description: ''
+  /polygon/{id}/:
+    get:
+      operationId: polygon_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this geo model.
+        required: true
+      tags:
+      - polygon
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Polygon'
+          description: ''
+components:
+  schemas:
+    Geometry:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          oneOf:
+          - type: object
+            properties:
+              type:
+                type: string
+                enum:
+                - Point
+              coordinates:
+                type: array
+                items:
+                  type: number
+                  format: float
+                example:
+                - 12.9721
+                - 77.5933
+                minItems: 2
+                maxItems: 3
+          - type: object
+            properties:
+              type:
+                type: string
+                enum:
+                - LineString
+              coordinates:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+                example:
+                - - 22.4707
+                  - 70.0577
+                - - 12.9721
+                  - 77.5933
+                minItems: 2
+          - type: object
+            properties:
+              type:
+                type: string
+                enum:
+                - Polygon
+              coordinates:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: number
+                      format: float
+                    example:
+                    - 12.9721
+                    - 77.5933
+                    minItems: 2
+                    maxItems: 3
+                  example:
+                  - - 22.4707
+                    - 70.0577
+                  - - 12.9721
+                    - 77.5933
+                  minItems: 4
+                example:
+                - - - 0.0
+                    - 0.0
+                  - - 0.0
+                    - 50.0
+                  - - 50.0
+                    - 50.0
+                  - - 50.0
+                    - 0.0
+                  - - 0.0
+                    - 0.0
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    GeometryList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Geometry'
+    Geometrycollection:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - GeometryCollection
+            coordinates:
+              type: array
+              items:
+                oneOf:
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - Point
+                    coordinates:
+                      type: array
+                      items:
+                        type: number
+                        format: float
+                      example:
+                      - 12.9721
+                      - 77.5933
+                      minItems: 2
+                      maxItems: 3
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - LineString
+                    coordinates:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: number
+                          format: float
+                        example:
+                        - 12.9721
+                        - 77.5933
+                        minItems: 2
+                        maxItems: 3
+                      example:
+                      - - 22.4707
+                        - 70.0577
+                      - - 12.9721
+                        - 77.5933
+                      minItems: 2
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - Polygon
+                    coordinates:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: number
+                            format: float
+                          example:
+                          - 12.9721
+                          - 77.5933
+                          minItems: 2
+                          maxItems: 3
+                        example:
+                        - - 22.4707
+                          - 70.0577
+                        - - 12.9721
+                          - 77.5933
+                        minItems: 4
+                      example:
+                      - - - 0.0
+                          - 0.0
+                        - - 0.0
+                          - 50.0
+                        - - 50.0
+                          - 50.0
+                        - - 50.0
+                          - 0.0
+                        - - 0.0
+                          - 0.0
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    GeometrycollectionList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Geometrycollection'
+    GisFeatureCollectionEnum:
+      type: string
+      enum:
+      - FeatureCollection
+    GisFeatureEnum:
+      type: string
+      enum:
+      - Feature
+    Linestring:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - LineString
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: number
+                  format: float
+                example:
+                - 12.9721
+                - 77.5933
+                minItems: 2
+                maxItems: 3
+              example:
+              - - 22.4707
+                - 70.0577
+              - - 12.9721
+                - 77.5933
+              minItems: 2
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    LinestringList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Linestring'
+    Multilinestring:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - MultiLineString
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+                example:
+                - - 22.4707
+                  - 70.0577
+                - - 12.9721
+                  - 77.5933
+                minItems: 2
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    MultilinestringList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Multilinestring'
+    Multipoint:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - MultiPoint
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: number
+                  format: float
+                example:
+                - 12.9721
+                - 77.5933
+                minItems: 2
+                maxItems: 3
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    MultipointList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Multipoint'
+    Multipolygon:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - MultiPolygon
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: number
+                      format: float
+                    example:
+                    - 12.9721
+                    - 77.5933
+                    minItems: 2
+                    maxItems: 3
+                  example:
+                  - - 22.4707
+                    - 70.0577
+                  - - 12.9721
+                    - 77.5933
+                  minItems: 4
+                example:
+                - - - 0.0
+                    - 0.0
+                  - - 0.0
+                    - 50.0
+                  - - 50.0
+                    - 50.0
+                  - - 50.0
+                    - 0.0
+                  - - 0.0
+                    - 0.0
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    MultipolygonList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Multipolygon'
+    PaginatedPlainList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Plain'
+    Plain:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        field_random1:
+          type: string
+          maxLength: 32
+        field_random2:
+          type: integer
+        field_gis_plain:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - Point
+            coordinates:
+              type: array
+              items:
+                type: number
+                format: float
+              example:
+              - 12.9721
+              - 77.5933
+              minItems: 2
+              maxItems: 3
+      required:
+      - field_gis_plain
+      - field_random1
+      - field_random2
+      - id
+    Point:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - Point
+            coordinates:
+              type: array
+              items:
+                type: number
+                format: float
+              example:
+              - 12.9721
+              - 77.5933
+              minItems: 2
+              maxItems: 3
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    PointList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Point'
+    Polygon:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureEnum'
+        id:
+          type: integer
+          readOnly: true
+        geometry:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - Polygon
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+                example:
+                - - 22.4707
+                  - 70.0577
+                - - 12.9721
+                  - 77.5933
+                minItems: 4
+              example:
+              - - - 0.0
+                  - 0.0
+                - - 0.0
+                  - 50.0
+                - - 50.0
+                  - 50.0
+                - - 50.0
+                  - 0.0
+                - - 0.0
+                  - 0.0
+        bbox:
+          type: array
+          items:
+            type: number
+          minItems: 4
+          maxItems: 4
+          example:
+          - 12.9721
+          - 77.5933
+          - 12.9721
+          - 77.5933
+        properties:
+          type: object
+          properties:
+            field_random1:
+              type: string
+              maxLength: 32
+            field_random2:
+              type: integer
+            field_gis_plain:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - Point
+                coordinates:
+                  type: array
+                  items:
+                    type: number
+                    format: float
+                  example:
+                  - 12.9721
+                  - 77.5933
+                  minItems: 2
+                  maxItems: 3
+    PolygonList:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/GisFeatureCollectionEnum'
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/Polygon'
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -5,9 +5,12 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from drf_spectacular.extensions import (
-    OpenApiAuthenticationExtension, OpenApiSerializerFieldExtension, OpenApiViewExtension,
+    OpenApiAuthenticationExtension, OpenApiSerializerExtension, OpenApiSerializerFieldExtension,
+    OpenApiViewExtension,
 )
-from drf_spectacular.plumbing import build_basic_type
+from drf_spectacular.plumbing import (
+    ResolvedComponent, build_array_type, build_basic_type, build_object_type,
+)
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from tests import generate_schema, get_response_schema
@@ -145,3 +148,48 @@ def test_multi_auth_scheme_extension(no_warnings):
         'appId': {'type': 'apiKey', 'in': 'header', 'name': 'X-APP-ID'}
     }
     assert schema['paths']['/x/']['get']['security'] == [{'apiKey': [], 'appId': []}]
+
+
+def test_serializer_list_extension(no_warnings):
+
+    class CustomListSerializer(serializers.ListSerializer):
+        def to_representation(self, data):
+            return {'foo': 1, 'data': super().to_representation(data)}   # pragma: no cover
+
+    # ListSerializer can be injected either via Meta attribute or by overriding many_init()
+    class XSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = SimpleModel
+            fields = '__all__'
+            list_serializer_class = CustomListSerializer
+
+    class CustomListExtension(OpenApiSerializerExtension):
+        target_class = CustomListSerializer
+
+        def map_serializer(self, auto_schema, direction):
+            component = auto_schema.resolve_serializer(self.target.child, direction)
+            schema = build_object_type(
+                properties={'foo': build_basic_type(int), 'data': build_array_type(component.ref)}
+            )
+            list_component = ResolvedComponent(
+                name=f'{component.name}List',
+                type=ResolvedComponent.SCHEMA,
+                object=self.target.child,
+                schema=schema
+            )
+            auto_schema.registry.register_on_missing(list_component)
+            return list_component.ref
+
+    class XViewset(mixins.ListModelMixin, viewsets.GenericViewSet):
+        serializer_class = XSerializer
+
+    schema = generate_schema('x', XViewset)
+    op_schema = get_response_schema(schema['paths']['/x/']['get'])
+    assert op_schema == {'$ref': '#/components/schemas/XList'}
+    assert schema['components']['schemas']['XList'] == {
+        'type': 'object',
+        'properties': {
+            'foo': {'type': 'integer'},
+            'data': {'type': 'array', 'items': {'$ref': '#/components/schemas/X'}}
+        }
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -140,3 +140,6 @@ ignore_missing_imports = True
 
 [mypy-rest_framework_dataclasses.*]
 ignore_missing_imports = True
+
+[mypy-rest_framework_gis.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Forked the schema code from [django-rest-framework-gis](https://github.com/openwisp/django-rest-framework-gis), fixed some issues and restructured the code to make it work with spectacular.

support for:

* GeoJSON responses (list/retrieve) for `GeoFeatureModelSerializer`
* geo fields in regular serializers
* geo pagination
* all geo fields supported including sane fallback for under-specified geometry field.

This supersedes previous effort for support in #38 #67 #743 and #744 

Feedback welcome!