### PR TITLE
Accept integer status codes in OpenApiExample

### DIFF
--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -129,7 +129,7 @@ class OpenApiExample(OpenApiSchemaBase):
             response_only: bool = False,
             parameter_only: Optional[Tuple[str, _ParameterLocationType]] = None,
             media_type: str = 'application/json',
-            status_codes: Optional[List[str]] = None,
+            status_codes: Optional[List[Union[str, int]]] = None,
     ):
         self.name = name
         self.summary = summary
@@ -140,7 +140,7 @@ class OpenApiExample(OpenApiSchemaBase):
         self.response_only = response_only
         self.parameter_only = parameter_only
         self.media_type = media_type
-        self.status_codes = status_codes or ['200', '201']
+        self.status_codes = list(map(str, status_codes)) if status_codes else ['200', '201']
 
 
 class OpenApiParameter(OpenApiSchemaBase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,6 +1,6 @@
 import pytest
 from rest_framework import __version__ as DRF_VERSION  # type: ignore[attr-defined]
-from rest_framework import generics, pagination, serializers, viewsets
+from rest_framework import generics, pagination, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -93,8 +93,14 @@ class ExampleTestWithExtendedViewSet(viewsets.GenericViewSet):
                 value={'field': 33},
             ),
             OpenApiExample(
-                'Create Error 403 Example',
-                value={'field': 'error'},
+                'Create Error 403 Integer Example',
+                value={'field': 'error (int)'},
+                response_only=True,
+                status_codes=[status.HTTP_403_FORBIDDEN],
+            ),
+            OpenApiExample(
+                'Create Error 403 String Example',
+                value={'field': 'error (str)'},
                 response_only=True,
                 status_codes=['403']
             ),

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -100,10 +100,14 @@ paths:
                 type: object
                 additionalProperties: {}
               examples:
-                CreateError403Example:
+                CreateError403IntegerExample:
                   value:
-                    field: error
-                  summary: Create Error 403 Example
+                    field: error (int)
+                  summary: Create Error 403 Integer Example
+                CreateError403StringExample:
+                  value:
+                    field: error (str)
+                  summary: Create Error 403 String Example
           description: ''
   /schema/{id}/:
     get:


### PR DESCRIPTION
... to be compatible with the rest_framework.status module