### PR TITLE
fix list pagination when examples are provided

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -1265,7 +1265,7 @@ def build_listed_example_value(value: Any, paginator, direction):
     schema = paginator.get_paginated_response_schema(sentinel)
     try:
         return {
-            field_name: value if field_schema is sentinel else field_schema['example']
+            field_name: [value] if field_schema is sentinel else field_schema['example']
             for field_name, field_schema in schema['properties'].items()
         }
     except (AttributeError, KeyError):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -177,7 +177,7 @@ def test_example_pagination(no_warnings):
                 'count': 123,
                 'next': 'http://api.example.org/accounts/?offset=400&limit=100',
                 'previous': 'http://api.example.org/accounts/?offset=200&limit=100',
-                'results': {'field': 111}
+                'results': [{'field': 111}],
             },
             'summary': 'Serializer C Example RO'
         }


### PR DESCRIPTION
The expected schema for a paginated list endpoint is
```
{
  ...,
  "results": [
    { ... },
    { ...},
  ],
}
```
Unit test validates that `results` is a single value, not a list