### PR TITLE
fix infinite recursion when accessing missing attributes in generator stats

### DIFF
--- a/drf_spectacular/drainage.py
+++ b/drf_spectacular/drainage.py
@@ -19,6 +19,8 @@ class GeneratorStats:
     _error_cache: DefaultDict[str, int] = defaultdict(int)
 
     def __getattr__(self, name):
+        if not name == 'silent':
+            raise AttributeError(name)
         if not self.__dict__:
             from drf_spectacular.settings import spectacular_settings
             self.silent = spectacular_settings.DISABLE_ERRORS_AND_WARNINGS

--- a/drf_spectacular/drainage.py
+++ b/drf_spectacular/drainage.py
@@ -19,12 +19,13 @@ class GeneratorStats:
     _error_cache: DefaultDict[str, int] = defaultdict(int)
 
     def __getattr__(self, name):
-        if not name == 'silent':
-            raise AttributeError(name)
         if not self.__dict__:
             from drf_spectacular.settings import spectacular_settings
             self.silent = spectacular_settings.DISABLE_ERRORS_AND_WARNINGS
-        return getattr(self, name)
+        try:
+            return self.__dict__[name]
+        except KeyError:
+            raise AttributeError(name)
 
     def __bool__(self):
         return bool(self._warn_cache or self._error_cache)

--- a/tests/test_generator_stats.py
+++ b/tests/test_generator_stats.py
@@ -1,0 +1,18 @@
+import inspect
+
+import pytest
+
+from drf_spectacular.drainage import GENERATOR_STATS
+
+
+def test_known_attribute_access_succeeds():
+    assert hasattr(GENERATOR_STATS, 'silent')
+
+
+def test_unknown_attribute_access_fails():
+    with pytest.raises(AttributeError):
+        getattr(GENERATOR_STATS, '__spam__')
+
+
+def test_inspect_unwrap():
+    assert inspect.unwrap(GENERATOR_STATS) is GENERATOR_STATS


### PR DESCRIPTION
This PR fixes a subtle issue in `drf_spectacular.drainage.GeneratorStats` class - when trying to access a missing attribute in its instance, the `getattr()` invocation will query `__getattr__` again since the attribute is still missing. Example:
```py
$ DJANGO_SETTINGS_MODULE='tests.settings' python
>>> from drf_spectacular.drainage import GeneratorStats
>>> stats = GeneratorStats()
>>> stats.spam
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ohoefling/projects/private/drf-spectacular/drf_spectacular/drainage.py", line 25, in __getattr__
    return getattr(self, name)
  File "/Users/ohoefling/projects/private/drf-spectacular/drf_spectacular/drainage.py", line 25, in __getattr__
    return getattr(self, name)
  File "/Users/ohoefling/projects/private/drf-spectacular/drf_spectacular/drainage.py", line 25, in __getattr__
    return getattr(self, name)
  [Previous line repeated 497 more times]
RecursionError: maximum recursion depth exceeded while calling a Python object
```
This has no effect at runtime since only the `silent` attribute is accessed in codebase, but it messes up doctests in our project that uses `drf-spectacular` for OpenAPI spec generation. More specifically, we import `GENERATOR_STATS` to disable warnings in a test, and this causes the object to be collected by `doctest` which then calls `inspect.unwrap(GENERATOR_STATS)` under the hood.

This can also be easily reproduced in the current `drf_spectacular` repository:
```
$ pytest --doctest-modules --ds=tests.settings drf_spectacular/drainage.py
===================================== test session starts ======================================
platform darwin -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0
django: settings: tests.settings (from option)
rootdir: /Users/ohoefling/projects/private/drf-spectacular
plugins: django-4.5.2, cov-3.0.0
collected 0 items / 1 error

============================================ ERRORS ============================================
_________________________ ERROR collecting drf_spectacular/drainage.py _________________________
drf_spectacular/drainage.py:25: in __getattr__
    return getattr(self, name)
drf_spectacular/drainage.py:25: in __getattr__
    return getattr(self, name)
drf_spectacular/drainage.py:25: in __getattr__
    return getattr(self, name)
E   RecursionError: maximum recursion depth exceeded while calling a Python object
!!! Recursion detected (same locals & position)
```

The fix only allows to access `silent` attribute, raising on any other one. Also added tests to maintain the code coverage.