### PR TITLE
Extend OpenApiSerializerExtension interface. #392 #705

### DIFF
--- a/drf_spectacular/extensions.py
+++ b/drf_spectacular/extensions.py
@@ -55,7 +55,7 @@ class OpenApiSerializerExtension(OpenApiGeneratorExtension['OpenApiSerializerExt
     """
     _registry: List['OpenApiSerializerExtension'] = []
 
-    def get_name(self) -> Optional[str]:
+    def get_name(self, auto_schema: 'AutoSchema', direction: Direction) -> Optional[str]:
         """ return str for overriding default name extraction """
         return None
 

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -1275,3 +1275,10 @@ def build_listed_example_value(value: Any, paginator, direction):
             f"provide example values themselves. Using the plain example value as fallback."
         )
         return value
+
+
+def filter_supported_arguments(func, **kwargs):
+    sig = inspect.signature(func)
+    return {
+        arg: val for arg, val in kwargs.items() if arg in sig.parameters
+    }


### PR DESCRIPTION
Addresses #392 and partially also #705

1. Allows get_name with full parameters without breaking legacy code.
2. enable calling ``auto_schema.resolve_serializer`` with
   ``bypass_extensions=True`` to allow offloading component creation