### PR TITLE
Arrays need to have the 'enum' and 'pattern' keys defined on the array item

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -330,6 +330,9 @@ def build_parameter_type(
         'name': name,
         'schema': {k: v for k, v in schema.items() if k not in irrelevant_field_meta},
     }
+    type_schema = schema['schema']
+    if type_schema['type'] == 'array':
+        type_schema = schema['schema']['items']
     if description:
         schema['description'] = description
     if required or location == 'path':
@@ -341,9 +344,9 @@ def build_parameter_type(
     if style is not None:
         schema['style'] = style
     if enum:
-        schema['schema']['enum'] = sorted(enum)
+        type_schema['enum'] = sorted(enum)
     if pattern is not None:
-        schema['schema']['pattern'] = pattern
+        type_schema['pattern'] = pattern
     if default is not None and 'default' not in irrelevant_field_meta:
         schema['schema']['default'] = default
     if not allow_blank and schema['schema'].get('type') == 'string':


### PR DESCRIPTION
Given this parameter definition:
```python
sort = OpenApiParameter(
    name='sort', location=OpenApiParameter.QUERY,
    description="Sort field", required=False, many=True, style='form',
    type=OpenApiTypes.STR, enum=['name', 'price', 'location'],
)
```
The current code generates parameter schemas like this:
```json
{
  "name": "sort", "in": "query", "description": "Sort field", "required": false,
  "schema": {
    "type": "array",
    "items": {
      "type": "str"
    },
    "enum": ["name", "price", "location"]
  },
  "style": "form"
}
```
The problem with this is that the enum is on the array type, not the items type.  This should be expressed as:
```json
{
  "name": "sort", "in": "query", "description": "Sort field", "required": false,
  "schema": {
    "type": "array",
    "items": {
      "type": "str",
      "enum": ["name", "price", "location"]
    }
  },
  "style": "form"
}
```
A similar problem happens with parameters defined as having a `OpenApiTypes.REGEX` type and a `pattern` parameter.

This code fixes that by putting both 'enum' and 'pattern' on the individual item type declaration.
Signed-off-by: Paul Wayper <paulway@redhat.com>