### PR TITLE
Make serializer context-aware

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1086,12 +1086,13 @@ class AutoSchema(ViewInspector):
 
     def _get_serializer(self):
         view = self.view
+        context = dict(request=view.request)
         try:
             if isinstance(view, GenericAPIView):
                 # try to circumvent queryset issues with calling get_serializer. if view has NOT
                 # overridden get_serializer, its safe to use get_serializer_class.
                 if view.__class__.get_serializer == GenericAPIView.get_serializer:
-                    return view.get_serializer_class()()
+                    return view.get_serializer_class()(context=context)
                 return view.get_serializer()
             elif isinstance(view, APIView):
                 # APIView does not implement the required interface, but be lenient and make
@@ -1099,7 +1100,7 @@ class AutoSchema(ViewInspector):
                 if callable(getattr(view, 'get_serializer', None)):
                     return view.get_serializer()
                 elif callable(getattr(view, 'get_serializer_class', None)):
-                    return view.get_serializer_class()()
+                    return view.get_serializer_class()(context=context)
                 elif hasattr(view, 'serializer_class'):
                     return view.serializer_class
                 else:


### PR DESCRIPTION
This is more of a question than a PR, not sure where the correct place for this is. We have serializers in our project which relies on the user group to dynamically determine which actions and which columns are accessible. Schema generation fails in this scenario as the Serializers don't get access to the view context / request. 

The fix is relatively trivial to fix in this repo imo, but is this the correct way of securing APIs?