### PR TITLE
Add support for Stoplight Elements docs UI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,8 @@ Features
     - Vendor specification extensions (``x-*``) in info, operations, parameters, components, and security schemes
     - Sane fallbacks
     - Sane ``operation_id`` naming (based on path)
-    - Schema serving with ``SpectacularAPIView`` (Redoc and Swagger-UI views are also available)
+    - Schema serving with ``SpectacularAPIView``
+    - `Elements <https://github.com/stoplightio/elements>`_, `Redoc <https://github.com/Redocly/redoc>`_, and `Swagger-UI <https://swagger.io/tools/swagger-ui/>`_ API documentation UI
     - Optional input/output serializer component split
     - Callback operations (experimental)
     - Included support for:
@@ -171,6 +172,7 @@ from your API. We also provide convenience wrappers for ``swagger-ui`` or ``redo
         # Optional UI:
         path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
         path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+        path('api/schema/elements/', SpectacularElementsView.as_view(url_name='schema'), name='elements'),
     ]
 
 Usage

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -81,6 +81,8 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SWAGGER_UI_DIST': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest',
     'SWAGGER_UI_FAVICON_HREF': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/favicon-32x32.png',
     'REDOC_DIST': 'https://cdn.jsdelivr.net/npm/redoc@latest',
+    'ELEMENTS_JS_DIST': 'https://unpkg.com/@stoplight/elements/web-components.min.js',
+    'ELEMENTS_CSS_DIST': 'https://unpkg.com/@stoplight/elements/styles.min.css',
 
     # Append OpenAPI objects to path and components in addition to the generated objects
     'APPEND_PATHS': {},

--- a/drf_spectacular/templates/drf_spectacular/elements.html
+++ b/drf_spectacular/templates/drf_spectacular/elements.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title|default:"Elements" }}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script src="{{ js_dist }}"></script>
+    <link rel="stylesheet" href="{{ css_dist }}">
+  </head>
+  <body>
+
+    <elements-api
+      apiDescriptionUrl="{{ schema_url }}"
+      router="hash"
+    />
+  </body>
+</html>

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -261,3 +261,34 @@ class SpectacularRedocView(APIView):
             lang=request.GET.get('lang'),
             version=request.GET.get('version')
         )
+
+
+class SpectacularElementsView(APIView):
+    renderer_classes = [TemplateHTMLRenderer]
+    permission_classes = spectacular_settings.SERVE_PERMISSIONS
+    authentication_classes = AUTHENTICATION_CLASSES
+    url_name = 'schema'
+    url = None
+    template_name = 'drf_spectacular/elements.html'
+    title = spectacular_settings.TITLE
+
+    @extend_schema(exclude=True)
+    def get(self, request, *args, **kwargs):
+
+        return Response(
+            data={
+                'title': self.title,
+                'js_dist': spectacular_settings.ELEMENTS_JS_DIST,
+                'css_dist': spectacular_settings.ELEMENTS_CSS_DIST,
+                'schema_url': self._get_schema_url(request),
+            },
+            template_name=self.template_name
+        )
+
+    def _get_schema_url(self, request):
+        schema_url = self.url or get_relative_url(reverse(self.url_name, request=request))
+        return set_query_parameters(
+            url=schema_url,
+            lang=request.GET.get('lang'),
+            version=request.GET.get('version')
+        )

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -12,7 +12,8 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.validation import validate_schema
 from drf_spectacular.views import (
-    SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerSplitView, SpectacularSwaggerView,
+    SpectacularAPIView, SpectacularElementsView, SpectacularRedocView, SpectacularSwaggerSplitView,
+    SpectacularSwaggerView,
 )
 
 
@@ -33,6 +34,7 @@ urlpatterns_v2 = [
     path('api/v2/schema/swagger-ui/', SpectacularSwaggerView.as_view(), name='swagger'),
     path('api/v2/schema/swagger-ui-alt/', SpectacularSwaggerSplitView.as_view(), name='swagger-alt'),
     path('api/v2/schema/redoc/', SpectacularRedocView.as_view(), name='redoc'),
+    path('api/v2/schema/elements/', SpectacularElementsView.as_view(), name='redoc'),
 ]
 urlpatterns_v2.append(
     path('api/v2/schema/', SpectacularAPIView.as_view(urlconf=urlpatterns_v2), name='schema'),
@@ -104,7 +106,7 @@ def test_spectacular_view_accept_unknown(no_warnings):
     )
 
 
-@pytest.mark.parametrize('ui', ['redoc', 'swagger-ui'])
+@pytest.mark.parametrize('ui', ['elements', 'redoc', 'swagger-ui'])
 @pytest.mark.urls(__name__)
 def test_spectacular_ui_view(no_warnings, ui):
     from drf_spectacular.settings import spectacular_settings
@@ -114,9 +116,13 @@ def test_spectacular_ui_view(no_warnings, ui):
     if ui == 'redoc':
         assert b'<title>Redoc</title>' in response.content
         assert spectacular_settings.REDOC_DIST.encode() in response.content
-    else:
+    elif ui == 'swagger-ui':
         assert b'<title>Swagger</title>' in response.content
         assert spectacular_settings.SWAGGER_UI_DIST.encode() in response.content
+    else:
+        assert b'<title>Elements</title>' in response.content
+        assert spectacular_settings.ELEMENTS_JS_DIST.encode() in response.content
+        assert spectacular_settings.ELEMENTS_CSS_DIST.encode() in response.content
     assert b'"/api/v2/schema/"' in response.content
 
 


### PR DESCRIPTION
Stoplight Elements is more recent OpenAPI docs UI that has some nice features compared to Swagger and Redoc. I thought this would be a useful addition to this (awesome!) project.

https://stoplight.io/open-source/elements