### PR TITLE
Add blueprint for Stoplight Elements docs UI

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -90,6 +90,17 @@ __ https://mrin9.github.io/RapiDoc/
 
 .. literalinclude:: blueprints/rapidoc.html
 
+Elements
+--------
+
+`Elements`__ is another documentation tool that can be used as an alternate to Redoc or Swagger UI.
+
+__ https://stoplight.io/open-source/elements
+
+.. literalinclude:: blueprints/elements.py
+
+.. literalinclude:: blueprints/elements.html
+
 
 drf-rw-serializers
 ------------------

--- a/docs/blueprints/elements.html
+++ b/docs/blueprints/elements.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title|default:"Elements" }}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script src="{{ js_dist }}"></script>
+    <link rel="stylesheet" href="{{ css_dist }}">
+  </head>
+  <body>
+    <elements-api apiDescriptionUrl="{{ schema_url }}" router="hash" />
+  </body>
+</html>

--- a/docs/blueprints/elements.py
+++ b/docs/blueprints/elements.py
@@ -1,0 +1,33 @@
+from rest_framework.renderers import TemplateHTMLRenderer
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+from rest_framework.views import APIView
+
+from drf_spectacular.plumbing import get_relative_url, set_query_parameters
+from drf_spectacular.settings import spectacular_settings
+from drf_spectacular.utils import extend_schema
+from drf_spectacular.views import AUTHENTICATION_CLASSES
+
+
+class SpectacularElementsView(APIView):
+     renderer_classes = [TemplateHTMLRenderer]
+     permission_classes = spectacular_settings.SERVE_PERMISSIONS
+     authentication_classes = AUTHENTICATION_CLASSES
+     url_name = 'schema'
+     url = None
+     template_name = 'elements.html'
+     title = spectacular_settings.TITLE
+
+     @extend_schema(exclude=True)
+     def get(self, request, *args, **kwargs):
+        schema_url = self.url or get_relative_url(reverse(self.url_name, request=request))
+        schema_url = set_query_parameters(schema_url, lang=request.GET.get('lang'), version=request.GET.get('version'))
+        return Response(
+            data={
+                'title': self.title,
+                'js_dist': 'https://unpkg.com/@stoplight/elements/web-components.min.js',
+                'css_dist': 'https://unpkg.com/@stoplight/elements/styles.min.css',
+                'schema_url': self._get_schema_url(request),
+            },
+            template_name=self.template_name
+        )


### PR DESCRIPTION
Following up from #794, this adds a blueprint for using Stoplight Elements, a more recent OpenAPI docs UI that has some nice features compared to Swagger and Redoc.

https://stoplight.io/open-source/elements