### PR TITLE
fix:  #816 NullBooleanField does not exist in DRF >= 3.14.0

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -811,7 +811,12 @@ class AutoSchema(ViewInspector):
 
             return append_meta(self._map_response_type_hint(method), meta)
 
-        if isinstance(field, (serializers.BooleanField, serializers.NullBooleanField)):
+        if hasattr(serializers, "NullBooleanField"):
+            boolean_field_classes = (serializers.BooleanField, serializers.NullBooleanField)
+        else:
+            boolean_field_classes = (serializers.BooleanField,)
+
+        if isinstance(field, boolean_field_classes):
             return append_meta(build_basic_type(OpenApiTypes.BOOL), meta)
 
         if isinstance(field, serializers.JSONField):


### PR DESCRIPTION
As several people noticed, drf-spectacular breaks with DRF 3.14.0, as `NullBooleanField` does not exist anymore.
This PR only check whether this class exists before trying to use it