### PR TITLE
Allow field extensions to return None from map_serializer_field

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -627,7 +627,9 @@ class AutoSchema(ViewInspector):
         serializer_field_extension = OpenApiSerializerFieldExtension.get_match(field)
         if serializer_field_extension and not bypass_extensions:
             schema = serializer_field_extension.map_serializer_field(self, direction)
-            if serializer_field_extension.get_name():
+            if schema is None:
+                return None
+            elif serializer_field_extension.get_name():
                 component = ResolvedComponent(
                     name=serializer_field_extension.get_name(),
                     type=ResolvedComponent.SCHEMA,

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -45,6 +45,31 @@ def test_serializer_field_extension(no_warnings):
     assert schema['components']['schemas']['X']['properties']['hash']['format'] == 'byte'
 
 
+def test_serializer_field_extension_can_return_none(no_warnings):
+    """Field extensions can return None, which should exclude them from schema"""
+
+    class Base64FieldExtension(OpenApiSerializerFieldExtension):
+        target_class = 'tests.test_extensions.Base64Field'
+
+        def map_serializer_field(self, auto_schema, direction):
+            return None
+
+    # At least 1 field is required to generate schema, include 'other'
+    class XSerializer(serializers.Serializer):
+        hash = Base64Field()
+        other = fields.CharField()
+
+    class XViewset(mixins.ListModelMixin, viewsets.GenericViewSet):
+        serializer_class = XSerializer
+
+    schema = generate_schema('x', XViewset)
+
+    # field 'hash' is missing from the schema output
+    assert schema['components']['schemas']['X'] == {
+        'type': 'object', 'properties': {'other': {'type': 'string'}}, 'required': ['other']
+    }
+
+
 class Base32Field(fields.Field):
     pass  # pragma: no cover
 


### PR DESCRIPTION
A field can be marked as ignored when generating by using `@extended_schema_field(None)` or `OpenApiTypes.NONE`.  This change extends the Extension processing so its behavior matches the decorator.