### PR TITLE
use `_default_manager` instead of `objects` as the manager for generic models

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -52,7 +52,7 @@ class DjangoFilterExtension(OpenApiFilterExtension):
         if not model:
             return []
 
-        filterset_class = self.target.get_filterset_class(auto_schema.view, model.objects.none())
+        filterset_class = self.target.get_filterset_class(auto_schema.view, model._default_manager.none())
         if not filterset_class:
             return []
 

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -561,13 +561,13 @@ class AutoSchema(ViewInspector):
             # special case handling only for _resolve_path_parameters() where neither queryset nor
             # parent is set by build_field. patch in queryset as _map_serializer_field requires it
             if not field.queryset:
-                field.queryset = model_field.related_model.objects.none()
+                field.queryset = model_field.related_model._default_manager.none()
             return self._map_serializer_field(field, direction)
         elif isinstance(field, serializers.ManyRelatedField):
             # special case handling similar to the case above. "parent.parent" on child_relation
             # is None and there is no queryset. patch in as _map_serializer_field requires one.
             if not field.child_relation.queryset:
-                field.child_relation.queryset = model_field.related_model.objects.none()
+                field.child_relation.queryset = model_field.related_model._default_manager.none()
             return self._map_serializer_field(field, direction)
         elif field and not isinstance(field, (serializers.ReadOnlyField, serializers.ModelField)):
             return self._map_serializer_field(field, direction)


### PR DESCRIPTION
This allows using the django_filters for models where the default manager isn't called `objects`.

See https://docs.djangoproject.com/en/3.2/topics/db/managers/#default-managers for the relevant Django documentation.