### PR TITLE
Use direct view methods for getting serializer instances in drf_rw_serializers schema blueprint

### DIFF
--- a/docs/blueprints/drf_rw_serializers.py
+++ b/docs/blueprints/drf_rw_serializers.py
@@ -8,10 +8,10 @@ class CustomAutoSchema(AutoSchema):
 
     def get_request_serializer(self):
         if isinstance(self.view, RWGenericAPIView):
-            return self.view.get_write_serializer_class()()
+            return self.view.get_write_serializer()
         return self._get_serializer()
 
     def get_response_serializers(self):
         if isinstance(self.view, RWGenericAPIView):
-            return self.view.get_read_serializer_class()()
+            return self.view.get_read_serializer()
         return self._get_serializer()


### PR DESCRIPTION
The methods that get instances can be customized by users, so going around them and using the type directly could go around the user customization.