### PR TITLE
Introduce setting DEFAULT_QUERY_MANAGER to allow other managers

### DIFF
--- a/drf_spectacular/contrib/django_filters.py
+++ b/drf_spectacular/contrib/django_filters.py
@@ -3,8 +3,8 @@ from django.db import models
 from drf_spectacular.drainage import add_trace_message, get_override, has_override, warn
 from drf_spectacular.extensions import OpenApiFilterExtension
 from drf_spectacular.plumbing import (
-    build_array_type, build_basic_type, build_parameter_type, follow_field_source, get_type_hints,
-    get_view_model, is_basic_type,
+    build_array_type, build_basic_type, build_parameter_type, follow_field_source, get_manager,
+    get_type_hints, get_view_model, is_basic_type,
 )
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
@@ -52,7 +52,7 @@ class DjangoFilterExtension(OpenApiFilterExtension):
         if not model:
             return []
 
-        filterset_class = self.target.get_filterset_class(auto_schema.view, model.objects.none())
+        filterset_class = self.target.get_filterset_class(auto_schema.view, get_manager(model).none())
         if not filterset_class:
             return []
 

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -30,7 +30,7 @@ from drf_spectacular.plumbing import (
     build_examples_list, build_generic_type, build_listed_example_value, build_media_type_object,
     build_mocked_view, build_object_type, build_parameter_type, build_serializer_context, error,
     filter_supported_arguments, follow_field_source, follow_model_field_lookup, force_instance,
-    get_doc, get_list_serializer, get_type_hints, get_view_model, is_basic_serializer,
+    get_doc, get_list_serializer, get_manager, get_type_hints, get_view_model, is_basic_serializer,
     is_basic_type, is_field, is_list_serializer, is_list_serializer_customized,
     is_patched_serializer, is_serializer, is_trivial_string_variation,
     modify_media_types_for_versioning, resolve_django_path_parameter, resolve_regex_path_parameter,
@@ -561,13 +561,13 @@ class AutoSchema(ViewInspector):
             # special case handling only for _resolve_path_parameters() where neither queryset nor
             # parent is set by build_field. patch in queryset as _map_serializer_field requires it
             if not field.queryset:
-                field.queryset = model_field.related_model.objects.none()
+                field.queryset = get_manager(model_field.related_model).none()
             return self._map_serializer_field(field, direction)
         elif isinstance(field, serializers.ManyRelatedField):
             # special case handling similar to the case above. "parent.parent" on child_relation
             # is None and there is no queryset. patch in as _map_serializer_field requires one.
             if not field.child_relation.queryset:
-                field.child_relation.queryset = model_field.related_model.objects.none()
+                field.child_relation.queryset = get_manager(model_field.related_model).none()
             return self._map_serializer_field(field, direction)
         elif field and not isinstance(field, (serializers.ReadOnlyField, serializers.ModelField)):
             return self._map_serializer_field(field, direction)

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -244,6 +244,16 @@ def get_openapi_type_mapping():
     }
 
 
+def get_manager(model):
+    if not hasattr(model, spectacular_settings.DEFAULT_QUERY_MANAGER):
+        error(
+            f'Failed to obtain queryset from model "{model.__name__}" because manager '
+            f'"{spectacular_settings.DEFAULT_QUERY_MANAGER}" was not found. You may '
+            f'need to change the DEFAULT_QUERY_MANAGER setting. bailing.'
+        )
+    return getattr(model, spectacular_settings.DEFAULT_QUERY_MANAGER)
+
+
 def build_generic_type():
     if spectacular_settings.GENERIC_ADDITIONAL_PROPERTIES is None:
         return {'type': 'object'}

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -149,6 +149,11 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # list responses with ListSerializers/many=True irrespective of the status code.
     'ENABLE_LIST_MECHANICS_ON_NON_2XX': False,
 
+    # This setting allows you to deviate from the default manager by accessing a different model
+    # property. We use "objects" by default for compatibility reasons. Using "_default_manager"
+    # will likely fix most issues, though you are free to choose any name.
+    "DEFAULT_QUERY_MANAGER": 'objects',
+
     # Controls which authentication methods are exposed in the schema. If not empty, will hide
     # authentication classes that are not contained in the whitelist. Use full import paths
     # like ['rest_framework.authentication.TokenAuthentication', ...]


### PR DESCRIPTION
Introduce setting `DEFAULT_QUERY_MANAGER` to allow other managers for queryset retrieval

closes #829 which had a hard coded solution. Thx @gera