### PR TITLE
add a view to handle SwaggerUI oauth callbacks

### DIFF
--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.templatetags.static import static
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
+from django.views.generic import RedirectView
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -261,3 +262,14 @@ class SpectacularRedocView(APIView):
             lang=request.GET.get('lang'),
             version=request.GET.get('version')
         )
+
+
+class SwaggerOauthRedirectView(RedirectView):
+    """
+    A view that serves the SwaggerUI oauth2-redirect.html file so that SwaggerUI can authenticate itself using Oauth2
+
+    This view should be served as ``./oauth2-redirect.html`` relative to the SwaggerUI itself.
+    If that is not possible, this views absolute url can also be set via the ``SPECTACULAR_SETTINGS.SWAGGER_UI_SETTINGS.oauth2RedirectUrl`` django settings.
+    """
+    def get_redirect_url(self, *args, **kwargs):
+        return _get_sidecar_url("swagger-ui-dist") + "/oauth2-redirect.html?" + self.request.GET.urlencode()

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -269,7 +269,8 @@ class SwaggerOauthRedirectView(RedirectView):
     A view that serves the SwaggerUI oauth2-redirect.html file so that SwaggerUI can authenticate itself using Oauth2
 
     This view should be served as ``./oauth2-redirect.html`` relative to the SwaggerUI itself.
-    If that is not possible, this views absolute url can also be set via the ``SPECTACULAR_SETTINGS.SWAGGER_UI_SETTINGS.oauth2RedirectUrl`` django settings.
+    If that is not possible, this views absolute url can also be set via the
+    ``SPECTACULAR_SETTINGS.SWAGGER_UI_SETTINGS.oauth2RedirectUrl`` django settings.
     """
     def get_redirect_url(self, *args, **kwargs):
         return _get_sidecar_url("swagger-ui-dist") + "/oauth2-redirect.html?" + self.request.GET.urlencode()

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -264,7 +264,7 @@ class SpectacularRedocView(APIView):
         )
 
 
-class SwaggerOauthRedirectView(RedirectView):
+class SpectacularSwaggerOauthRedirectView(RedirectView):
     """
     A view that serves the SwaggerUI oauth2-redirect.html file so that SwaggerUI can authenticate itself using Oauth2
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -185,4 +185,5 @@ def test_swagger_oauth_redirect_view(get_params):
         # older django versions test client directly returns the response instance
         assert response.url == '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params
     else:
-        assert response.headers['Location'] == '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params
+        assert response.headers['Location'] ==\
+               '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -13,6 +13,7 @@ from drf_spectacular.utils import extend_schema
 from drf_spectacular.validation import validate_schema
 from drf_spectacular.views import (
     SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerSplitView, SpectacularSwaggerView,
+    SwaggerOauthRedirectView,
 )
 
 
@@ -31,6 +32,7 @@ urlpatterns_v2 = [
     path('api/v2/pi/', pi),
     path('api/v2/pi-fast/', pi),
     path('api/v2/schema/swagger-ui/', SpectacularSwaggerView.as_view(), name='swagger'),
+    path("api/v1/schema/swagger-ui/oauth2-redirect.html", SwaggerOauthRedirectView.as_view(), name="swagger-oauth-redirect"),
     path('api/v2/schema/swagger-ui-alt/', SpectacularSwaggerSplitView.as_view(), name='swagger-alt'),
     path('api/v2/schema/redoc/', SpectacularRedocView.as_view(), name='redoc'),
 ]
@@ -165,3 +167,11 @@ def test_spectacular_urlconf_module_list_import(no_warnings, url):
 def test_spectacular_urlconf_module_list_import_error(no_warnings, url):
     with pytest.raises(ModuleNotFoundError):
         APIClient().get(url)
+
+
+@pytest.mark.parametrize('get_params', ['', 'code=foobar123&state=xyz&session_state=hello-world'])
+@pytest.mark.urls(__name__)
+def test_swagger_oauth_redirect_view(get_params):
+    response = APIClient().get('/api/v1/schema/swagger-ui/oauth2-redirect.html?' + get_params)
+    assert response.status_code == 302
+    assert response.headers['Location'] == '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 import yaml
 from django import __version__ as DJANGO_VERSION
+from django.http import HttpResponseRedirect
 from django.urls import path
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -175,6 +176,13 @@ def test_spectacular_urlconf_module_list_import_error(no_warnings, url):
 @pytest.mark.parametrize('get_params', ['', 'code=foobar123&state=xyz&session_state=hello-world'])
 @pytest.mark.urls(__name__)
 def test_swagger_oauth_redirect_view(get_params):
+    # act
     response = APIClient().get('/api/v1/schema/swagger-ui/oauth2-redirect.html?' + get_params)
+
+    # assert
     assert response.status_code == 302
-    assert response.headers['Location'] == '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params
+    if isinstance(response, HttpResponseRedirect):
+        # older django versions test client directly returns the response instance
+        assert response.url == '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params
+    else:
+        assert response.headers['Location'] == '/static/drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html?' + get_params

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -13,7 +13,7 @@ from drf_spectacular.utils import extend_schema
 from drf_spectacular.validation import validate_schema
 from drf_spectacular.views import (
     SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerSplitView, SpectacularSwaggerView,
-    SwaggerOauthRedirectView,
+    SpectacularSwaggerOauthRedirectView,
 )
 
 
@@ -32,7 +32,10 @@ urlpatterns_v2 = [
     path('api/v2/pi/', pi),
     path('api/v2/pi-fast/', pi),
     path('api/v2/schema/swagger-ui/', SpectacularSwaggerView.as_view(), name='swagger'),
-    path("api/v1/schema/swagger-ui/oauth2-redirect.html", SwaggerOauthRedirectView.as_view(), name="swagger-oauth-redirect"),
+    path(
+        "api/v1/schema/swagger-ui/oauth2-redirect.html",
+        SpectacularSwaggerOauthRedirectView.as_view(),
+        name="swagger-oauth-redirect"),
     path('api/v2/schema/swagger-ui-alt/', SpectacularSwaggerSplitView.as_view(), name='swagger-alt'),
     path('api/v2/schema/redoc/', SpectacularRedocView.as_view(), name='redoc'),
 ]

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -13,8 +13,8 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.validation import validate_schema
 from drf_spectacular.views import (
-    SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerSplitView, SpectacularSwaggerView,
-    SpectacularSwaggerOauthRedirectView,
+    SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerOauthRedirectView,
+    SpectacularSwaggerSplitView, SpectacularSwaggerView,
 )
 
 


### PR DESCRIPTION
This is a re-opening of https://github.com/tfranzel/drf-spectacular-sidecar/pull/5

This PR adds a view so that SwaggerUI can authenticate itself using Oauth2 (or Openid-Connect) by serving the callback HTML file.
The view is implemented as a redirect to the static callback HTML file, since it is part of the SwaggerUI distribution and does not require any special handling from Django.

Additionally, a new test has been written to validate the view's correct redirect location including get parameters (which are used by OAuth to communicate authentication results to SwaggerUI).