### PR TITLE
Include filename in call to _get_sidecar_url

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/redoc.html
+++ b/drf_spectacular/templates/drf_spectacular/redoc.html
@@ -15,14 +15,14 @@
   <body>
     {% if settings %}
     <div id="redoc-container"></div>
-    <script src="{{ dist }}/bundles/redoc.standalone.js"></script>
+    <script src="{{ redoc_standalone }}"></script>
     <script>
       const redocSettings = {{ settings|safe }};
       Redoc.init("{{ schema_url }}", redocSettings, document.getElementById('redoc-container'))
     </script>
     {% else %}
     <redoc spec-url="{{ schema_url }}"></redoc>
-    <script src="{{ dist }}/bundles/redoc.standalone.js"></script>
+    <script src="{{ redoc_standalone }}"></script>
     {% endif %}
   </body>
 </html>

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% if favicon_href %}<link rel="icon" href="{{ favicon_href }}">{% endif %}
-    <link rel="stylesheet" href="{{ dist }}/swagger-ui.css">
+    <link rel="stylesheet" href="{{ swagger_ui_css }}">
     <style>
       html { box-sizing: border-box; overflow-y: scroll; }
       *, *:after, *:before { box-sizing: inherit; }
@@ -14,8 +14,8 @@
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="{{ dist }}/swagger-ui-bundle.js"></script>
-    <script src="{{ dist }}/swagger-ui-standalone-preset.js"></script>
+    <script src="{{ swagger_ui_bundle }}"></script>
+    <script src="{{ swagger_ui_standalone }}"></script>
     {% if script_url %}
     <script src="{{ script_url }}"></script>
     {% else %}

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -133,7 +133,9 @@ class SpectacularSwaggerView(APIView):
         return Response(
             data={
                 'title': self.title,
-                'dist': self._swagger_ui_dist(),
+                'swagger_ui_css': self._swagger_ui_resource('swagger-ui.css'),
+                'swagger_ui_bundle': self._swagger_ui_resource('swagger-ui-bundle.js'),
+                'swagger_ui_standalone': self._swagger_ui_resource('swagger-ui-standalone-preset.js'),
                 'favicon_href': self._swagger_ui_favicon(),
                 'schema_url': self._get_schema_url(request),
                 'settings': self._dump(spectacular_settings.SWAGGER_UI_SETTINGS),
@@ -172,14 +174,16 @@ class SpectacularSwaggerView(APIView):
         ]
         return [auth.name for auth in auth_extensions if auth]
 
-    def _swagger_ui_dist(self):
+    @staticmethod
+    def _swagger_ui_resource(filename):
         if spectacular_settings.SWAGGER_UI_DIST == 'SIDECAR':
-            return _get_sidecar_url('swagger-ui-dist')
-        return spectacular_settings.SWAGGER_UI_DIST
+            return _get_sidecar_url(f'swagger-ui-dist/{filename}')
+        return f'{spectacular_settings.SWAGGER_UI_DIST}/{filename}'
 
-    def _swagger_ui_favicon(self):
+    @staticmethod
+    def _swagger_ui_favicon():
         if spectacular_settings.SWAGGER_UI_FAVICON_HREF == 'SIDECAR':
-            return _get_sidecar_url('swagger-ui-dist') + '/favicon-32x32.png'
+            return _get_sidecar_url('swagger-ui-dist/favicon-32x32.png')
         return spectacular_settings.SWAGGER_UI_FAVICON_HREF
 
 
@@ -209,7 +213,9 @@ class SpectacularSwaggerSplitView(SpectacularSwaggerView):
             return Response(
                 data={
                     'title': self.title,
-                    'dist': self._swagger_ui_dist(),
+                    'swagger_ui_css': self._swagger_ui_resource('swagger-ui.css'),
+                    'swagger_ui_bundle': self._swagger_ui_resource('swagger-ui-bundle.js'),
+                    'swagger_ui_standalone': self._swagger_ui_resource('swagger-ui-standalone-preset.js'),
                     'favicon_href': self._swagger_ui_favicon(),
                     'script_url': set_query_parameters(
                         url=script_url,
@@ -235,7 +241,7 @@ class SpectacularRedocView(APIView):
         return Response(
             data={
                 'title': self.title,
-                'dist': self._redoc_dist(),
+                'redoc_standalone': self._redoc_standalone(),
                 'schema_url': self._get_schema_url(request),
                 'settings': self._dump(spectacular_settings.REDOC_UI_SETTINGS),
             },
@@ -250,10 +256,11 @@ class SpectacularRedocView(APIView):
         else:
             return json.dumps(data, indent=2)
 
-    def _redoc_dist(self):
+    @staticmethod
+    def _redoc_standalone():
         if spectacular_settings.REDOC_DIST == 'SIDECAR':
-            return _get_sidecar_url('redoc')
-        return spectacular_settings.REDOC_DIST
+            return _get_sidecar_url('redoc/bundles/redoc.standalone.js')
+        return f'{spectacular_settings.REDOC_DIST}/bundles/redoc.standalone.js'
 
     def _get_schema_url(self, request):
         schema_url = self.url or get_relative_url(reverse(self.url_name, request=request))
@@ -273,4 +280,4 @@ class SpectacularSwaggerOauthRedirectView(RedirectView):
     ``SPECTACULAR_SETTINGS.SWAGGER_UI_SETTINGS.oauth2RedirectUrl`` django settings.
     """
     def get_redirect_url(self, *args, **kwargs):
-        return _get_sidecar_url("swagger-ui-dist") + "/oauth2-redirect.html?" + self.request.GET.urlencode()
+        return _get_sidecar_url("swagger-ui-dist/oauth2-redirect.html") + "?" + self.request.GET.urlencode()


### PR DESCRIPTION
@tfranzel Based on your advice in #847, I moved the filenames for the different resources out of the templates and into the call to _get_sidecar_url(). Please let me know if you have any other suggestions. Thank you!

I've tested with the sidecar and with the regular CDN, using both a manifest backend and non-manifest backend. This fixes the bug with the combination of a manifest backend and the sidecar, without causing any regression I can see for the other three cases.

Fixes #847 