### PR TITLE
fix: let use a default value for foreignkey model field

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -948,7 +948,14 @@ class AutoSchema(ViewInspector):
                 if not field.read_only:
                     meta['minLength'] = 1
         if field.default is not None and field.default != empty and not callable(field.default):
-            if isinstance(field, (serializers.ModelField, serializers.SerializerMethodField)):
+            if isinstance(
+                field,
+                (
+                    serializers.ModelField,
+                    serializers.SerializerMethodField,
+                    serializers.PrimaryKeyRelatedField,
+                ),
+            ):
                 # Skip coercion for lack of a better solution. ModelField.to_representation()
                 # and SerializerMethodField.to_representation() are special in that they require
                 # a model instance or object (which we don't have) instead of a plain value.


### PR DESCRIPTION
If there is a default value in a model foreign key ('0' im my case), the actual code calls ```field.to_representation(field.default)``` and tries to interpret ```field.default.pk``` and raises an error.  This fix let use raw default value.

See Django documentation : https://docs.djangoproject.com/en/4.1/ref/models/fields/#default

> For fields like [ForeignKey](https://docs.djangoproject.com/en/4.1/ref/models/fields/#django.db.models.ForeignKey) that map to model instances, defaults should be the value of the field they reference (pk unless [to_field](https://docs.djangoproject.com/en/4.1/ref/models/fields/#django.db.models.ForeignKey.to_field) is set) instead of model instances.

