### PR TITLE
Don't let validators override values already set in the schema

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1031,20 +1031,24 @@ class AutoSchema(ViewInspector):
         for v in field.validators:
             if schema_type == 'string':
                 if isinstance(v, validators.EmailValidator):
-                    schema['format'] = 'email'
+                    if 'format' not in schema:
+                        schema['format'] = 'email'
                 elif isinstance(v, validators.URLValidator):
-                    schema['format'] = 'uri'
+                    if 'format' not in schema:
+                        schema['format'] = 'uri'
                 elif isinstance(v, validators.RegexValidator):
-                    pattern = v.regex.pattern.encode('ascii', 'backslashreplace').decode()
-                    pattern = pattern.replace(r'\x', r'\u00')  # unify escaping
-                    pattern = pattern.replace(r'\Z', '$').replace(r'\A', '^')  # ECMA anchors
-                    schema['pattern'] = pattern
+                    if 'pattern' not in schema:
+                        pattern = v.regex.pattern.encode('ascii', 'backslashreplace').decode()
+                        pattern = pattern.replace(r'\x', r'\u00')  # unify escaping
+                        pattern = pattern.replace(r'\Z', '$').replace(r'\A', '^')  # ECMA anchors
+                        schema['pattern'] = pattern
                 elif isinstance(v, validators.MaxLengthValidator):
                     update_constraint(schema, 'maxLength', min, v.limit_value)
                 elif isinstance(v, validators.MinLengthValidator):
                     update_constraint(schema, 'minLength', max, v.limit_value)
                 elif isinstance(v, validators.FileExtensionValidator) and v.allowed_extensions:
-                    schema['pattern'] = '(?:%s)$' % '|'.join([re.escape(extn) for extn in v.allowed_extensions])
+                    if 'pattern' not in schema:
+                        schema['pattern'] = '(?:%s)$' % '|'.join([re.escape(extn) for extn in v.allowed_extensions])
             elif schema_type in ('integer', 'number'):
                 if isinstance(v, validators.MaxValueValidator):
                     update_constraint(schema, 'maximum', min, v.limit_value)

--- a/tests/test_extend_schema.py
+++ b/tests/test_extend_schema.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
 
 from drf_spectacular.openapi import AutoSchema
+from drf_spectacular.plumbing import build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiParameter, extend_schema, extend_schema_field, extend_schema_serializer,
@@ -33,10 +34,21 @@ class CustomField(serializers.Field):
         return urlsafe_base64_encode(b'\xf0\xf1\xf2')  # pragma: no cover
 
 
+@extend_schema_field(OpenApiTypes.BYTE)
+class CustomURLField(serializers.URLField):
+    def to_representation(self, value):
+        return urlsafe_base64_encode(b'\xf0\xf1\xf2')  # pragma: no cover
+
+@extend_schema_field({"oneOf": [build_basic_type(OpenApiTypes.URI), {"enum": [""], "type": "string"}]})
+class BlankUrlField(serializers.URLField):
+    pass
+
+
 @extend_schema_serializer(component_name='GammaEpsilon')
 class GammaSerializer(serializers.Serializer):
     encoding = serializers.CharField()
     image_data = CustomField()
+    blank_url_field = BlankUrlField()
 
 
 class InlineSerializer(serializers.Serializer):

--- a/tests/test_extend_schema.py
+++ b/tests/test_extend_schema.py
@@ -39,6 +39,7 @@ class CustomURLField(serializers.URLField):
     def to_representation(self, value):
         return urlsafe_base64_encode(b'\xf0\xf1\xf2')  # pragma: no cover
 
+
 @extend_schema_field({"oneOf": [build_basic_type(OpenApiTypes.URI), {"enum": [""], "type": "string"}]})
 class BlankUrlField(serializers.URLField):
     pass

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -375,7 +375,15 @@ components:
         image_data:
           type: string
           format: byte
+        blank_url_field:
+          oneOf:
+          - type: string
+            format: uri
+          - enum:
+            - ''
+            type: string
       required:
+      - blank_url_field
       - encoding
       - image_data
     Inline:


### PR DESCRIPTION
This at least resolves the bug that I encountered in the workaround for [this issue](https://github.com/tfranzel/drf-spectacular/issues/909#issuecomment-1371203466).
I have included a test case that validates that `@extend_schema_field` is working for custom URLFields, which it was not previously