### PR TITLE
Remove 'Authorize' button from GUI

### DIFF
--- a/drf_spectacular/hooks.py
+++ b/drf_spectacular/hooks.py
@@ -143,6 +143,12 @@ def postprocess_schema_enums(result, generator, **kwargs):
     return result
 
 
+def postprocess_schema_security_definitions(result, generator, **kwargs):
+    """Post-process the schema's security definitions."""
+    result["components"].pop("securitySchemes")
+    return result
+
+
 def preprocess_exclude_path_format(endpoints, **kwargs):
     """
         preprocessing hook that filters out {format} suffixed paths, in case


### PR DESCRIPTION
I know there's some interest in a solution to help getting rid of the "Authorize" button from the GUI when no authentication classes are specified for the relevant endpoints.

After some tinkering I managed to hide it by just removing the related portion from the schema.

Thought of sharing the hook, which might be developed further in a proper proposal. What are your thoughts, @tfranzel?