### PR TITLE
Add support for drf ReturnList and ReturnDict type hint

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -37,6 +37,7 @@ from rest_framework.compat import unicode_http_header
 from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
 from rest_framework.utils.mediatypes import _MediaType
+from rest_framework.utils.serializer_helpers import ReturnList, ReturnDict
 from uritemplate import URITemplate
 
 from drf_spectacular.drainage import cache, error, warn
@@ -1224,7 +1225,7 @@ def resolve_type_hint(hint):
         else:
             properties = {k: build_basic_type(OpenApiTypes.ANY) for k in hint._fields}
         return build_object_type(properties=properties, required=properties.keys())
-    elif origin is list or hint is list:
+    elif origin is list or hint is list or hint is ReturnList:
         return build_array_type(
             resolve_type_hint(args[0]) if args else build_basic_type(OpenApiTypes.ANY)
         )
@@ -1234,7 +1235,7 @@ def resolve_type_hint(hint):
             max_length=len(args),
             min_length=len(args),
         )
-    elif origin is dict or origin is defaultdict or origin is OrderedDict:
+    elif origin is dict or origin is defaultdict or origin is OrderedDict or hint is ReturnDict:
         schema = build_basic_type(OpenApiTypes.OBJECT)
         if args and args[1] is not typing.Any:
             schema['additionalProperties'] = resolve_type_hint(args[1])

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -37,7 +37,7 @@ from rest_framework.compat import unicode_http_header
 from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
 from rest_framework.utils.mediatypes import _MediaType
-from rest_framework.utils.serializer_helpers import ReturnList, ReturnDict
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 from uritemplate import URITemplate
 
 from drf_spectacular.drainage import cache, error, warn


### PR DESCRIPTION
While using `SerialilzerMethodField` to return ListSerializer data, the result type is `ReturnList`:

```
from rest_framework import serializers
from rest_framework.utils.serializer_helpers import ReturnList

class MySerializer(serializers.ModelSerializer):
    items = serializers.SerializerMethodField()

    class Meta:
        model = MyModel
        fields = '__all__'

    def get_items(self, obj) -> ReturnList:
        queryset = obj.items.all()[::-1]
        return ItemSerializer(queryset, many=True, read_only=True).data
```

And will got a waring:

```
Warning [MyViewSet > MySerializer]: unable to resolve type hint for function "get_items". Consider using a type hint or @extend_schema_field. Defaulting to string.
```

Because it can't resolve `ReturnList` type.
