### PR TITLE
Add swagger UI template blocks

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -39,7 +39,7 @@ Example: SwaggerUI settings
 ---------------------------
 
 We currently support passing through all basic SwaggerUI `configuration parameters <https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/>`_.
-For more customization options (e.g. JS functions), you can modify and override the
+For more customization options (e.g. CSS, JS functions), you can extend or override the
 `SwaggerUI template <https://github.com/tfranzel/drf-spectacular/blob/master/drf_spectacular/templates/drf_spectacular/swagger_ui.html>`_
 in your project files.
 

--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.html
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    {% block head %}
     <title>{{ title|default:"Swagger" }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,8 +12,10 @@
       *, *:after, *:before { box-sizing: inherit; }
       body { background: #fafafa; margin: 0; }
     </style>
+    {% endblock head %}
   </head>
   <body>
+    {% block body %}
     <div id="swagger-ui"></div>
     <script src="{{ swagger_ui_bundle }}"></script>
     <script src="{{ swagger_ui_standalone }}"></script>
@@ -23,5 +26,6 @@
     {% include template_name_js %}
     </script>
     {% endif %}
+    {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
First, on behalf of my several teams where we've been using _drf_spectacular_ - a huge thank you to @tfranzel and all the other contributors for developing this project.

I noticed that the idea of template tags in `swagger_ui.html` is not new and has already been brought up in [this pull request](https://github.com/tfranzel/drf-spectacular/pull/486). I read the comments there, and would like to address @tfranzel 's issues raised there:

- >**not that it matters much, but the `block` is not nested inside a `extends` which renders it non-functional afaik**

  That is not correct. Defining e.g. `{% block body %}` in the template does not change the way the template is rendered, but instead it enables accessing and overriding this block in any template that _extends the original template_ (see [Django docs on template inheritance](https://docs.djangoproject.com/en/4.1/ref/templates/language/#template-inheritance)). What really matters is that instead of _overriding_ the entire template it allows for _extending_ it.

- >**`custom_scripts` is below the js section. i could come up with a case, where it would also make sense to have it above. adding custom_scripts_before and custom_scripts_after seems kind of over the top.**
  
  That is a perfectly valid point. What feels more robust to me is just enclosing the entire `head` and `body` tags in django template tags. This way, any content can be added at the beginning or at the end of these tags. I also think it's safe to say that any _further_ customization should indeed be solved by completely overriding the template.

So here's my proposition to add two basic template tags to the `swagger_ui.html` template:

- `{% block head %} {% endblock %}`
- `{% block body %} {% endblock %}`

Which allows to:

- add custom html at the end / beginning of `<body>`
- add custom html at the end / beginning of `<head>`

For example:

```html
<!-- myproject/templates/drf_spectacular/swagger_ui.html -->

{% extends "drf_spectacular/swagger_ui.html" %}

{% block body %}

    {{ block.super }}

    <script src='https://... '></script>
    <style> body, html { ... } </style>

{% endblock %}
```

And why is _extending_ the template better than _overriding_ it? Because in case anything changes in the original template, these changes won't be lost when extending the template, and they are when completely overriding it.
Also introducing a docs mention about it.

Looking forward to see what you think. Have a great day!