### PR TITLE
Add support to "x-tagGroups"

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -478,6 +478,8 @@ def build_root_object(paths, components, version):
         root['servers'] = settings.SERVERS
     if settings.TAGS:
         root['tags'] = settings.TAGS
+    if settings.TAG_GROUPS:
+        root['x-tagGroups'] = settings.TAG_GROUPS
     if settings.EXTERNAL_DOCS:
         root['externalDocs'] = settings.EXTERNAL_DOCS
     return root

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -190,14 +190,14 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
 
     # Tags defined in the global scope. Determines the order of appearance and allows
     # to configure additional information for each tag.
-    # e.g. [{'name': 'AUTH:SESSION', 'description': 'Text', 'x-displayName': 'Session'}]
+    # e.g. [{'name': 'Auth:Session', 'description': 'Text', 'x-displayName': 'Session'}]
     # https://redocly.com/docs/api-reference-docs/specification-extensions/x-display-name/
     'TAGS': [],
 
     # If present, it HAS TO denote each tag that appears in the documentation.
     # Otherwise, operations associated with a tag not enlisted here, will not appear
     # at all.
-    # e.g. [{'name': 'Accounts', 'tags': ['AUTH_SESSION']}]
+    # e.g. [{'name': 'Accounts', 'tags': ['Auth:Session']}]
     # https://redocly.com/docs/api-reference-docs/specification-extensions/x-tag-groups/
     'TAG_GROUPS': [],
 

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -187,8 +187,20 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # Each entry MUST contain "url", MAY contain "description", "variables"
     # e.g. [{'url': 'https://example.com/v1', 'description': 'Text'}, ...]
     'SERVERS': [],
-    # Tags defined in the global scope
+
+    # Tags defined in the global scope. Determines the order of appearance and allows
+    # to configure additional information for each tag.
+    # e.g. [{'name': 'AUTH:SESSION', 'description': 'Text', 'x-displayName': 'Session'}]
+    # https://redocly.com/docs/api-reference-docs/specification-extensions/x-display-name/
     'TAGS': [],
+
+    # If present, it HAS TO denote each tag that appears in the documentation.
+    # Otherwise, operations associated with a tag not enlisted here, will not appear
+    # at all.
+    # e.g. [{'name': 'Accounts', 'tags': ['AUTH_SESSION']}]
+    # https://redocly.com/docs/api-reference-docs/specification-extensions/x-tag-groups/
+    'TAG_GROUPS': [],
+
     # Optional: MUST contain 'url', may contain "description"
     'EXTERNAL_DOCS': {},
 


### PR DESCRIPTION
This pull request adds a possibility of extending the generated schema with "x-tagGroups".

The approach is similar to the "TAGS" configuration option which is already present in the settings.

Consider the following tags definition:

```python
    "TAGS": [
        {"name": "Auth:Session", "x-displayName": "Session"},
        {"name": "Accounts:Register", "x-displayName": "Register"},
        {"name": "Accounts:Maintenance", "x-displayName": "Maintenance"},
        {"name": "Accounts:Details", "x-displayName": "Details"},
    ]
```

The goal is to enable users to group the tags (and so the operations) in a more detailed manner. This is especially useful in case of larger APIs that might consist of tons of operations.

Let's consider the example above. The documentation will easily become more readable being split into different sections. One for the "Authentication" and second for the "Accounts".

Please find the image attached. This is exactly what I did for my exact purpose.

![Zrzut ekranu 2023-02-1 o 15 11 00](https://user-images.githubusercontent.com/730971/216066112-22138f75-7f8b-4208-a0c7-0986c0fd3997.png)

Redocly specification comes in handy with a perfect tool for this specific use case:

- https://redocly.com/docs/api-reference-docs/specification-extensions/x-tag-groups/

In order to accomplish the results as might be seen on the screen above, you will only have to extend the `SPECTACULAR_SETTINGS` with an additional array of dictionaries. Like so:

```python
    "TAG_GROUPS": [
        {
            "name": "Authentication",
            "tags": ["Auth:Session"]
        },
        {
            "name": "Accounts",
            "tags": ["Accounts:Register", "Accounts:Maintenance", "Accounts:Details"],
        },
    ]
```

I've also updated the comment in the spectacular defaults:
- next to "TAGS" configuration option to showcase the fact it is possible to use extensions in a tag definition
- next to the "TAG_GROUPS" (the one I've created) to point out the important notice from the "x-tagGroups" specification that states:

> When using x-tagGroups, a tag that is not in a group will not be displayed at all. You must add every tag to at least one group.