### PR TITLE
mitigate `runtests.py` fail when GDAL library is not installed …

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -8,7 +8,7 @@ import sys
 import pytest
 
 PYTEST_ARGS = {
-    'default': ['tests'],
+    'default': ['tests', '--allow-skip-extra-system-req'],
     'fast': ['tests', '-q'],
 }
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -101,3 +101,15 @@ def get_response_schema(operation, status=None, content_type='application/json')
 
 def get_request_schema(operation, content_type='application/json'):
     return operation['requestBody']['content'][content_type]['schema']
+
+
+def is_gis_installed():
+    # only load GIS if library is installed. This is required for the GIS test to work
+    from django.core.exceptions import ImproperlyConfigured
+
+    try:
+        from django.contrib.gis.gdal import gdal_version  # noqa: F401
+    except ImproperlyConfigured:
+        return False
+    else:
+        return True

--- a/tests/contrib/test_rest_framework_gis.py
+++ b/tests/contrib/test_rest_framework_gis.py
@@ -6,10 +6,11 @@ from rest_framework import __version__ as DRF_VERSION  # type: ignore[attr-defin
 from rest_framework import mixins, routers, serializers, viewsets
 
 from drf_spectacular.utils import extend_schema_serializer
-from tests import assert_schema, generate_schema
+from tests import assert_schema, generate_schema, is_gis_installed
 
 
 @pytest.mark.contrib('rest_framework_gis')
+@pytest.mark.system_requirement_fulfilled(is_gis_installed())
 @pytest.mark.skipif(DRF_VERSION < '3.12', reason='DRF pagination schema broken')
 @mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {})
 def test_rest_framework_gis(no_warnings, clear_caches):
@@ -90,6 +91,7 @@ def test_rest_framework_gis(no_warnings, clear_caches):
 
 
 @pytest.mark.contrib('rest_framework_gis', 'django_filter')
+@pytest.mark.system_requirement_fulfilled(is_gis_installed())
 @mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {})
 def test_geo_filter_set(no_warnings):
     from django.contrib.gis.db.models import PointField

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,11 @@ exclude_lines =
     if __name__ == .__main__.:
     if TYPE_CHECKING:
 
+[pytest]
+markers =
+    contrib: marks upstream package dependency
+    system_requirement_fulfilled: marks system library dependency.
+
 [flake8]
 ignore =
     # line break before binary operator


### PR DESCRIPTION
#945 #821 #775 #777

will coventiently make ``./runtests.py`` brush over system library requirements to help contributors run the test suite locally without installing extra stuff.

full tox run will require it though.