### PR TITLE
Add option to provide a callable for PolymorphicProxySerializer.serializers

### DIFF
--- a/drf_spectacular/utils.py
+++ b/drf_spectacular/utils.py
@@ -64,11 +64,19 @@ class PolymorphicProxySerializer(Serializer):
     *drf-spectacular* processes the serializer. In those cases you can explicitly state
     the mapping with ``{'legal': LegalPersonSerializer, ...}``, but it is then your
     responsibility to have a valid mapping.
+
+    It is also permissible to provide a callable with no parameters for ``serializers``,
+    such as a lambda that will return an appropriate list or dict when evaluated.
     """
     def __init__(
             self,
             component_name: str,
-            serializers: Union[Sequence[_SerializerType], Dict[str, _SerializerType]],
+            serializers: Union[
+                Sequence[_SerializerType],
+                Dict[str, _SerializerType],
+                Callable[[], Sequence[_SerializerType]],
+                Callable[[], Dict[str, _SerializerType]]
+            ],
             resource_type_field_name: Optional[str],
             many: Optional[bool] = None,
     ):
@@ -87,6 +95,16 @@ class PolymorphicProxySerializer(Serializer):
             instance = super().__new__(cls, *args, **kwargs)
         instance._many = many
         return instance
+
+    @property
+    def serializers(self):
+        if callable(self._serializers):
+            self._serializers = self._serializers()
+        return self._serializers
+
+    @serializers.setter
+    def serializers(self, value):
+        self._serializers = value
 
     @property
     def data(self):


### PR DESCRIPTION
Adding a minor feature that we found useful in our own use of `PolymorphicProxySerializer` - the ability to initialize it with a callable (such as a lambda) that returns a list/dict of `serializers` when evaluated, rather than needing to provide the list of serializers up front at declaration time.

In our case this was useful because we have a polymorphic schema method field that can return a serializer corresponding to any subclass of a given abstract base model, not all of which may already be defined/imported at the time the field is declared. Being able to provide a callback that can be deferred until the time the schema is actually generated made our implementation easier.