### PR TITLE
Fix test warnings

### DIFF
--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3039,31 +3039,31 @@ def test_slug_related_field_to_model_property(no_warnings):
 
 
 def test_serializer_foreign_key_default_value_handling(no_warnings):
-    class M10(models.Model):
+    class M12(models.Model):
         field = models.CharField(unique=True)
 
-    class M11(models.Model):
-        field_related = models.ForeignKey(M10, on_delete=models.CASCADE, default=1)
+    class M13(models.Model):
+        field_related = models.ForeignKey(M12, on_delete=models.CASCADE, default=1)
 
     class XSerializer(serializers.ModelSerializer):
         field_related = serializers.PrimaryKeyRelatedField(
-            queryset=M11.objects.all(),
+            queryset=M13.objects.all(),
             default=1,
         )
         field_related_slug = serializers.SlugRelatedField(
             source='field_related',
             slug_field='field',
-            queryset=M10.objects.all(),
+            queryset=M12.objects.all(),
             default='foo',
         )
 
         class Meta:
             fields = '__all__'
-            model = M11
+            model = M13
 
     class XViewset(viewsets.ModelViewSet):
         serializer_class = XSerializer
-        queryset = M11.objects.none()
+        queryset = M13.objects.none()
 
     schema = generate_schema('/x', XViewset)
     assert schema['components']['schemas']['X']['properties'] == {


### PR DESCRIPTION
Fix RuntimeWarning during testing:
```
tests/test_regressions.py::test_serializer_foreign_key_default_value_handling                                                                                                                                        
  /home/incred/dev/drf-spectacular/venv/lib64/python3.11/site-packages/django/db/models/base.py:364: RuntimeWarning: Model 'tests.m10' was already registered. Reloading models is not advised as it can lead to inco
nsistencies, most notably with related models.                                                                                                                                                                       
    new_class._meta.apps.register_model(new_class._meta.app_label, new_class)                                                                                                                                        
                                                                                                                                                                                                                     
tests/test_regressions.py::test_serializer_foreign_key_default_value_handling
  /home/incred/dev/drf-spectacular/venv/lib64/python3.11/site-packages/django/db/models/base.py:364: RuntimeWarning: Model 'tests.m11' was already registered. Reloading models is not advised as it can lead to inco
nsistencies, most notably with related models.
    new_class._meta.apps.register_model(new_class._meta.app_label, new_class)
```
Renamed those model's classes using new names to avoid warnings.