### PR TITLE
fix jwt cookie name settings not being recognised

### DIFF
--- a/drf_spectacular/contrib/rest_auth.py
+++ b/drf_spectacular/contrib/rest_auth.py
@@ -155,7 +155,24 @@ class SimpleJWTCookieScheme(SimpleJWTScheme):
         return [{name: []} for name in self.name]
 
     def get_security_definition(self, auto_schema):
-        cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
+
+        from dj_rest_auth.app_settings import api_settings
+
+        try:
+            from dj_rest_auth.__version__ import __version__ as dj_rest_auth_version
+
+        except ModuleNotFoundError:
+            # dj_rest_auth version < 1.0.5 does not have __version__ file
+            # so by assigning a version number (i.e. 1.0.4 in this case)
+            # we can check if it is less than 3.0.0 later on in the code
+            dj_rest_auth_version = "1.0.4"  # 1.0.4 or less in reality
+
+        cookie_name = getattr(api_settings, 'JWT_AUTH_COOKIE', None)
+
+        # fallback for dj_rest_auth version < 3.0.0
+        if int(dj_rest_auth_version.split(".")[0]) < 3 and not cookie_name:
+            cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
+
         if not cookie_name:
             cookie_name = 'jwt-auth'
             warn(

--- a/drf_spectacular/contrib/rest_auth.py
+++ b/drf_spectacular/contrib/rest_auth.py
@@ -155,24 +155,7 @@ class SimpleJWTCookieScheme(SimpleJWTScheme):
         return [{name: []} for name in self.name]
 
     def get_security_definition(self, auto_schema):
-
-        from dj_rest_auth.app_settings import api_settings
-
-        try:
-            from dj_rest_auth.__version__ import __version__ as dj_rest_auth_version
-
-        except ModuleNotFoundError:
-            # dj_rest_auth version < 1.0.5 does not have __version__ file
-            # so by assigning a version number (i.e. 1.0.4 in this case)
-            # we can check if it is less than 3.0.0 later on in the code
-            dj_rest_auth_version = "1.0.4"  # 1.0.4 or less in reality
-
-        cookie_name = getattr(api_settings, 'JWT_AUTH_COOKIE', None)
-
-        # fallback for dj_rest_auth version < 3.0.0
-        if int(dj_rest_auth_version.split(".")[0]) < 3 and not cookie_name:
-            cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
-
+        cookie_name = get_dj_rest_auth_setting('JWT_AUTH_COOKIE', 'JWT_AUTH_COOKIE')
         if not cookie_name:
             cookie_name = 'jwt-auth'
             warn(

--- a/tests/contrib/test_rest_auth.py
+++ b/tests/contrib/test_rest_auth.py
@@ -51,6 +51,7 @@ def test_rest_auth_token(no_warnings, settings):
 
 @pytest.mark.contrib('dj_rest_auth', 'rest_framework_simplejwt')
 @mock.patch('django.conf.settings.JWT_AUTH_COOKIE', 'jwt-session', create=True)
+@mock.patch('dj_rest_auth.app_settings.api_settings.JWT_AUTH_COOKIE', 'jwt-session', create=True)
 def test_rest_auth_simplejwt_cookie(no_warnings):
     from dj_rest_auth.jwt_auth import JWTCookieAuthentication
 


### PR DESCRIPTION
Issue #971 

This should fix the issue by getting the cookie_name from the dj_rest_auth.app_settings instead of Django settings in the original code. I also fix the test case that is associated with this method. I Ran tests locally and everything seems fine from my side. Please let me know if anything needs to be improved. Thanks!