### PR TITLE
fix: Camelize query parameters

### DIFF
--- a/drf_spectacular/contrib/djangorestframework_camel_case.py
+++ b/drf_spectacular/contrib/djangorestframework_camel_case.py
@@ -36,5 +36,10 @@ def camelize_serializer_fields(result, generator, request, public):
         if component_type == 'schemas':
             camelize_component(component.schema)
 
+    for url_schema in result["paths"].values():
+        for method_schema in url_schema.values():
+            for parameter in method_schema.get("parameters", []):
+                parameter["name"] = camelize_str(parameter["name"])
+
     # inplace modification of components also affect result dict, so regeneration is not necessary
     return result

--- a/tests/contrib/test_djangorestframework_camel_case.py
+++ b/tests/contrib/test_djangorestframework_camel_case.py
@@ -14,7 +14,7 @@ else:
     from typing_extensions import TypedDict
 
 from drf_spectacular.contrib.djangorestframework_camel_case import camelize_serializer_fields
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from tests import assert_schema, generate_schema
 
 
@@ -46,6 +46,16 @@ class FakeSerializer(serializers.Serializer):
         pass  # pragma: no cover
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            name="field_one",
+            description="filter_field",
+            required=False,
+            type=str,
+        ),
+    ]
+)
 class FakeViewset(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = FakeSerializer
 

--- a/tests/contrib/test_djangorestframework_camel_case.yml
+++ b/tests/contrib/test_djangorestframework_camel_case.yml
@@ -6,6 +6,12 @@ paths:
   /a_b_c/:
     get:
       operationId: a_b_c_list
+      parameters:
+      - in: query
+        name: fieldOne
+        schema:
+          type: string
+        description: filter_field
       tags:
       - a_b_c
       security:
@@ -24,6 +30,12 @@ paths:
   /a_b_c/home/:
     get:
       operationId: a_b_c_home_retrieve
+      parameters:
+      - in: query
+        name: fieldOne
+        schema:
+          type: string
+        description: filter_field
       tags:
       - a_b_c
       security:


### PR DESCRIPTION
I noticed that when using djangorestframework-camel-case, parameters don't convert to camel case.