### PR TITLE
selectively distinguish real serializers from mocked ones #1006

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -101,11 +101,11 @@ def force_instance(serializer_or_field):
         return serializer_or_field
 
 
-def is_serializer(obj) -> bool:
+def is_serializer(obj, strict=False) -> bool:
     from drf_spectacular.serializers import OpenApiSerializerExtension
     return (
         isinstance(force_instance(obj), serializers.BaseSerializer)
-        or bool(OpenApiSerializerExtension.get_match(obj))
+        or (bool(OpenApiSerializerExtension.get_match(obj)) and not strict)
     )
 
 
@@ -119,7 +119,7 @@ def get_list_serializer(obj):
 
 def is_list_serializer_customized(obj) -> bool:
     return (
-        is_serializer(obj)
+        is_serializer(obj, strict=True)
         and get_class(get_list_serializer(obj)).to_representation  # type: ignore
         is not serializers.ListSerializer.to_representation
     )


### PR DESCRIPTION
This addresses an issue where we enter a code path that only works for real serializers, while the check also allows for objects covered by OpenApiSerializerExtension.
However when checking for customized ListSerializers, we are only interested in actual serializers so distinguish the cases.