### PR TITLE
add Authorization header for oauth2 in swagger ui schema request

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.js
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.js
@@ -85,6 +85,9 @@ const injectAuthCredentials = (request) => {
     } else if (authDef.schema.type === "apiKey" && authDef.schema.in === "header") {
       request.headers[authDef.schema.name] = authDef.value;
       return;
+    } else if (authDef.schema.type === "oauth2" && authDef.token.token_type === "Bearer") {
+      request.headers["Authorization"] = `Bearer ${authDef.token.access_token}`;
+      return;
     }
   }
 };


### PR DESCRIPTION
I was trying to add swagger to my drf application which is using `django-oauth-toolkit`, my api should not be accessible by everyone so I used this config:

```python

SPECTACULAR_SETTINGS = {
    'TITLE': API_TITLE,
    'DESCRIPTION': API_DESCRIPTION,
    'VERSION': '0.2.0',
    'SERVE_INCLUDE_SCHEMA': True,
    'SWAGGER_UI_DIST': 'SIDECAR',
    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',

    'SWAGGER_UI_SETTINGS': {
        'persistAuthorization': True,
    },
    'SERVE_PUBLIC': False,
    'AUTHENTICATION_WHITELIST': [
        'rest_framework.authentication.TokenAuthentication',
        'oauth2_provider.contrib.rest_framework.OAuth2Authentication'
    ],
    'SERVE_PERMISSIONS': ['rest_framework.permissions.AllowAny'],

    'SERVE_AUTHENTICATION': [
        'rest_framework.authentication.TokenAuthentication',
        'oauth2_provider.contrib.rest_framework.OAuth2Authentication'
    ],
    'OAUTH2_FLOWS': ['password'],
    'OAUTH2_AUTHORIZATION_URL': '/o/authorize/',
    'OAUTH2_TOKEN_URL': '/o/token/',
    'OAUTH2_REFRESH_URL': '/o/token/',
    'OAUTH2_SCOPES': OAUTH2_PROVIDER['SCOPES'],
}
```

When using `TokenAuthentication` everything was ok (`Authorization` header was added to both **schema** and **api** requests), but when I tried using `OAuth2Authentication` my **api** requests where ok but the **schema** request did not receive `Authorization` token.

The problem was in `swagger-ui.js` where id didn't try reading `oauth2` config stored in the browser.