### PR TITLE
Fixing Pydantic Extension

### DIFF
--- a/docs/blueprints/pydantic.py
+++ b/docs/blueprints/pydantic.py
@@ -1,7 +1,7 @@
 from drf_spectacular.extensions import OpenApiSerializerExtension
 from drf_spectacular.plumbing import ResolvedComponent
 
-from pydantic import model_schema
+from pydantic.schema import model_schema
 
 
 class PydanticExtension(OpenApiSerializerExtension):

--- a/docs/blueprints/pydantic.py
+++ b/docs/blueprints/pydantic.py
@@ -1,36 +1,29 @@
 from drf_spectacular.extensions import OpenApiSerializerExtension
 from drf_spectacular.plumbing import ResolvedComponent
 
+from pydantic import model_schema
+
 
 class PydanticExtension(OpenApiSerializerExtension):
-    target_class = 'pydantic.BaseModel'
+    target_class = "pydantic.BaseModel"
     match_subclasses = True
 
     def get_name(self, auto_schema, direction):
         return self.target.__name__
 
     def map_serializer(self, auto_schema, direction):
-        def translate_refs(obj, key=None):
-            if isinstance(obj, dict):
-                return {k: translate_refs(v, k) for k, v in obj.items()}
-            elif isinstance(obj, list):
-                return [translate_refs(i) for i in obj]
-            elif key == '$ref':
-                return obj.replace('#/definitions/', '#/components/schemas/')
-            else:
-                return obj
 
         # let pydantic generate a JSON schema
-        schema = self.target.schema()
+        schema = model_schema(self.target, ref_prefix="#/components/schemas/")
 
         # pull out potential sub-schemas and put them into component section
-        for sub_name, sub_schema in schema.pop('definitions', {}).items():
+        for sub_name, sub_schema in schema.pop("definitions", {}).items():
             component = ResolvedComponent(
                 name=sub_name,
                 type=ResolvedComponent.SCHEMA,
                 object=sub_name,
-                schema=translate_refs(sub_schema),
+                schema=sub_schema,
             )
             auto_schema.registry.register_on_missing(component)
 
-        return translate_refs(schema)
+        return schema


### PR DESCRIPTION
Hey tfranzel,

Thanks for your help with adding support for `pydantic` a few weeks ago.

It came to my attention earlier today while running some tests that the `__schema_cache__` from `pydantic` was causing problems when any of the pages associated with the schema views were refreshed. The `model_schema` function from `pydantic` doesn't use a cache, whereas the `model.schema()` does utilize this cache. Additionally, the `ref_prefix` param of the `model_schema` function allows for the removal of some of the other functionality we hard coded.

I came up with the above solution based on the `pydantic` documentation as well as [this previously opened issue](https://github.com/tfranzel/drf-spectacular/issues/801).

Let me know what you think!