### PR TITLE
Add a blueprint for pydantic 2

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -155,4 +155,10 @@ Pydantic
 Preliminary support for `Pydantic <https://github.com/pydantic/pydantic>`_  models. This may or may not
 end up in the main package. Catches decorated Pydantic classes and integrates their schema.
 
+Pydantic 1:
+
 .. literalinclude:: blueprints/pydantic.py
+
+Pydantic 2:
+
+.. literalinclude:: blueprints/pydantic2.py

--- a/docs/blueprints/pydantic2.py
+++ b/docs/blueprints/pydantic2.py
@@ -1,0 +1,29 @@
+from drf_spectacular.extensions import OpenApiSerializerExtension
+from drf_spectacular.plumbing import ResolvedComponent
+
+from pydantic.json_schema import model_json_schema
+
+
+class PydanticExtension(OpenApiSerializerExtension):
+    target_class = "pydantic.BaseModel"
+    match_subclasses = True
+
+    def get_name(self, auto_schema, direction):
+        return self.target.__name__
+
+    def map_serializer(self, auto_schema, direction):
+
+        # let pydantic generate a JSON schema
+        schema = model_json_schema(self.target, ref_template="#/components/schemas")
+
+        # pull out potential sub-schemas and put them into component section
+        for sub_name, sub_schema in schema.pop("definitions", {}).items():
+            component = ResolvedComponent(
+                name=sub_name,
+                type=ResolvedComponent.SCHEMA,
+                object=sub_name,
+                schema=sub_schema,
+            )
+            auto_schema.registry.register_on_missing(component)
+
+        return schema


### PR DESCRIPTION
Add a blueprint to support pydantic models, using the pydantic 2.x version.