### PR TITLE
fix django-polymorphic empty serializer case #1029 #542

### DIFF
--- a/tests/contrib/test_rest_polymorphic.py
+++ b/tests/contrib/test_rest_polymorphic.py
@@ -113,10 +113,17 @@ def test_rest_polymorphic_split_request_with_ro_serializer(no_warnings):
     assert components['PersonRequest']['oneOf'] == [
         {'$ref': '#/components/schemas/LegalPersonTypedRequest'},
         {'$ref': '#/components/schemas/NaturalPersonTypedRequest'},
+        {'$ref': '#/components/schemas/NomadicPersonTypedRequest'},
     ]
     assert components['PersonRequest']['discriminator']['mapping'] == {
         'legal': '#/components/schemas/LegalPersonTypedRequest',
         'natural': '#/components/schemas/NaturalPersonTypedRequest',
+        'nomadic': '#/components/schemas/NomadicPersonTypedRequest',
+    }
+    assert components['NomadicPersonTypedRequest'] == {
+        'properties': {'resourcetype': {'type': 'string'}},
+        'required': ['resourcetype'],
+        'type': 'object',
     }
 
 


### PR DESCRIPTION
#542 fixed an assertion error when a sub-serializer had no fields (or only had RO/WO fields).

However, it is a valid case that a sub-serializer may be empty (except for the `resource_type_field`). Usually we would just have an empty body, but here it is a bit more involved. This fix includes that case without building an empty component.

@ngnpope fyi since you authored #542, this likely also affects you.