### PR TITLE
Add option of configure throttling for Spectacular's views

### DIFF
--- a/docs/blueprints/elements.py
+++ b/docs/blueprints/elements.py
@@ -6,13 +6,15 @@ from rest_framework.views import APIView
 from drf_spectacular.plumbing import get_relative_url, set_query_parameters
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.utils import extend_schema
-from drf_spectacular.views import AUTHENTICATION_CLASSES
+from drf_spectacular.views import AUTHENTICATION_CLASSES, THROTTLE_CLASSES
 
 
 class SpectacularElementsView(APIView):
      renderer_classes = [TemplateHTMLRenderer]
      permission_classes = spectacular_settings.SERVE_PERMISSIONS
      authentication_classes = AUTHENTICATION_CLASSES
+     throttle_classes = THROTTLE_CLASSES
+     throttle_scope = spectacular_settings.SERVE_THROTTLE_SCOPE
      url_name = 'schema'
      url = None
      template_name = 'elements.html'

--- a/docs/blueprints/rapidoc.py
+++ b/docs/blueprints/rapidoc.py
@@ -6,13 +6,15 @@ from rest_framework.views import APIView
 from drf_spectacular.plumbing import get_relative_url, set_query_parameters
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.utils import extend_schema
-from drf_spectacular.views import AUTHENTICATION_CLASSES
+from drf_spectacular.views import AUTHENTICATION_CLASSES, THROTTLE_CLASSES
 
 
 class SpectacularRapiDocView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
+    throttle_classes = THROTTLE_CLASSES
+    throttle_scope = spectacular_settings.SERVE_THROTTLE_SCOPE
     url_name = 'schema'
     url = None
     template_name = 'rapidoc.html'

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -54,6 +54,10 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SERVE_PERMISSIONS': ['rest_framework.permissions.AllowAny'],
     # None will default to DRF's AUTHENTICATION_CLASSES
     'SERVE_AUTHENTICATION': None,
+    # None will default to DRF's THROTTLE_CLASSES
+    'SERVE_THROTTLE': None,
+    # can be used to define a unique throttle key for ScopedRateThrottle for spectacular's views.
+    'SERVE_THROTTLE_SCOPE': 'schema',
 
     # Dictionary of general configuration to pass to the SwaggerUI({ ... })
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
@@ -217,6 +221,7 @@ IMPORT_STRINGS = [
     'DEFAULT_GENERATOR_CLASS',
     'SERVE_AUTHENTICATION',
     'SERVE_PERMISSIONS',
+    'SERVE_THROTTLE',
     'POSTPROCESSING_HOOKS',
     'PREPROCESSING_HOOKS',
     'GET_LIB_DOC_EXCLUDES',

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -39,6 +39,11 @@ if spectacular_settings.SERVE_AUTHENTICATION is not None:
 else:
     AUTHENTICATION_CLASSES = api_settings.DEFAULT_AUTHENTICATION_CLASSES
 
+if spectacular_settings.SERVE_THROTTLE is not None:
+    THROTTLE_CLASSES = spectacular_settings.SERVE_THROTTLE
+else:
+    THROTTLE_CLASSES = api_settings.DEFAULT_THROTTLE_CLASSES
+
 
 class SpectacularAPIView(APIView):
     __doc__ = _("""
@@ -52,6 +57,8 @@ class SpectacularAPIView(APIView):
     ]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
+    throttle_classes = THROTTLE_CLASSES
+    throttle_scope = spectacular_settings.SERVE_THROTTLE_SCOPE
     generator_class = spectacular_settings.DEFAULT_GENERATOR_CLASS
     serve_public = spectacular_settings.SERVE_PUBLIC
     urlconf = spectacular_settings.SERVE_URLCONF
@@ -122,6 +129,8 @@ class SpectacularSwaggerView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
+    throttle_classes = THROTTLE_CLASSES
+    throttle_scope = spectacular_settings.SERVE_THROTTLE_SCOPE
     url_name = 'schema'
     url = None
     template_name = 'drf_spectacular/swagger_ui.html'
@@ -231,6 +240,8 @@ class SpectacularRedocView(APIView):
     renderer_classes = [TemplateHTMLRenderer]
     permission_classes = spectacular_settings.SERVE_PERMISSIONS
     authentication_classes = AUTHENTICATION_CLASSES
+    throttle_classes = THROTTLE_CLASSES
+    throttle_scope = spectacular_settings.SERVE_THROTTLE_SCOPE
     url_name = 'schema'
     url = None
     template_name = 'drf_spectacular/redoc.html'


### PR DESCRIPTION
Hi @tfranzel,

I use heavy trottling for anonymous users in my DRF based project and I noticed that I'm getting `429 Too Many Requests` errors when I'm not signed in and try to load schema related pages. After a while I realized that's because Spectacular's views use the `DEFAULT_THROTTLE_CLASSES` from my settings. I think it would be pretty great if it can be configured like everything else so I created this change.

I treid to add tests but as views are initialised on test startup it's hard to override the settings.

Let me know what do you think! Thanks!