### PR TITLE
Catch custom list view actions in _is_list_view

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -129,6 +129,10 @@ class AutoSchema(ViewInspector):
             return True
         if is_basic_type(serializer):
             return False
+        if hasattr(self.view, "detail"):
+            if not self.view.detail and self.method.lower() == "get":
+                # non-detail get request is a list view by definition
+                return True
         if hasattr(self.view, 'action'):
             return self.view.action == 'list'
         # list responses are "usually" only returned by GET


### PR DESCRIPTION
If I create an action on a viewset via
```
@action(
    detail=False,
    methods=["GET"]
)
def my_custom_action(...):
    ...
```
then spectacular doesn't list filter params as query params, even though this custom action will accept them, since `self.view.action != 'list'`. This PR fixes that by adding an additional heuristic.