### PR TITLE
Change _is_list_view heuristic to support other list actions

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -130,7 +130,7 @@ class AutoSchema(ViewInspector):
         if is_basic_type(serializer):
             return False
         if hasattr(self.view, 'action'):
-            return self.view.action == 'list'
+            return "list" in self.view.action
         # list responses are "usually" only returned by GET
         if self.method != 'GET':
             return False

--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -130,7 +130,7 @@ class AutoSchema(ViewInspector):
         if is_basic_type(serializer):
             return False
         if hasattr(self.view, 'action'):
-            return "list" in self.view.action
+            return bool(re.search(r"(?:\b|_)list(?:\b|_)", self.view.action))
         # list responses are "usually" only returned by GET
         if self.method != 'GET':
             return False


### PR DESCRIPTION
When using Django Rest Framework with Django Filters if you want to add a new action to your ViewSet that behave exactly like a "list" action, DRF-Spectacular doesn't see it as a list action which make it ignore generating the schema generation for its specific filters. By checking if an action contain the pure word "list" we can support those edge cases.

If you don't like this modification please provide a better solution, otherwise please merge it :D 

P.S. If I should be making any chance before merging please tell me to do so

Please check commit description for more technical information about my changes.