### PR TITLE
Handle http method names passed for views in DRF for correct schema generation

### DIFF
--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -75,7 +75,19 @@ class EndpointEnumerator(BaseEndpointEnumerator):
         return api_endpoints
 
     def get_allowed_methods(self, callback):
-        methods = super().get_allowed_methods(callback)
+        if hasattr(callback, 'actions'):
+            actions = set(callback.actions)
+            http_method_names = set(callback.cls.http_method_names)
+            methods = [method.upper() for method in actions & http_method_names]
+        else:
+            # pass to constructor allowed method names to get valid ones
+            kwargs = {}
+            http_method_names = callback.initkwargs.get('http_method_names', [])
+            if http_method_names:
+                kwargs['http_method_names'] = http_method_names
+
+            methods = callback.cls(**kwargs).allowed_methods
+
         return [
             method for method in methods
             if method not in ('OPTIONS', 'HEAD', 'TRACE', 'CONNECT')


### PR DESCRIPTION
DRF does not handle 'http_method_names' argument for `as_view()` constructor when returning allowed method names for a view/endpoint, so if you pass explicitly any, schema will be generated by all existing, not only allowed.
These changes below correctly handle this issue.