### PR TITLE
Add Python 3.12 to test matrix and add classifiers

### DIFF
--- a/requirements/optionals.txt
+++ b/requirements/optionals.txt
@@ -2,6 +2,7 @@ django-allauth<0.55.0  # breaking change breaking dj-rest-auth
 drf-jwt>=0.13.0
 dj-rest-auth>=1.0.0
 djangorestframework-simplejwt>=4.4.0
+setuptools
 django-polymorphic>=2.1
 django-rest-polymorphic>=0.1.8
 django-oauth-toolkit>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Documentation',
         'Topic :: Software Development :: Code Generators',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def pytest_configure(config):
             'django.middleware.common.CommonMiddleware',
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.middleware.locale.LocaleMiddleware',
+            'allauth.account.middleware.AccountMiddleware',
         ),
         INSTALLED_APPS=(
             'django.contrib.auth',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,6 @@ def pytest_configure(config):
             'django.middleware.common.CommonMiddleware',
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.middleware.locale.LocaleMiddleware',
-            'allauth.account.middleware.AccountMiddleware',
         ),
         INSTALLED_APPS=(
             'django.contrib.auth',

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -15,6 +15,7 @@ try:
     )
 except ImportError:
     JWTAuthentication = None
+    JWTTokenUserAuthentication = None
 
 
 class XSerializer(serializers.Serializer):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
        {py37,py38,py39}-django{3.2}-drf{3.11,3.12},
        {py38,py39,py310}-django{4.0,4.1}-drf{3.13,3.14},
        {py311}-django{4.1, 4.2}-drf{3.14},
+       {py312}-django{4.2}-drf{3.14},
        py310-django4.2-drfmaster
        py310-djangomaster-drf3.14
        py310-drfmaster-djangomaster


### PR DESCRIPTION
`djangorestframework-simplejwt` is not yet compatible with Python 3.12. Took me a while to figure out that the real errors gets silenced.

https://github.com/tfranzel/drf-spectacular/blob/6e48a704b9767fdcd72820c42fd8878b4f75cdd0/tests/contrib/test_simplejwt.py#L8-L18

Is this is something acceptable in a different PR I'm happily to submit. 
```python
except ImportError as e:
    if "rest_framework_simplejwt" in str(e):
        JWTAuthentication = None
    else:
        raise e
```