### PR TITLE
Provide all fixed field names for the components object in ResolvedComponent.* constants

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -680,8 +680,18 @@ def alpha_operation_sorter(endpoint):
 
 
 class ResolvedComponent:
+    # OpenAPI 3.0.3
     SCHEMA = 'schemas'
+    RESPONSE = 'responses'
+    PARAMETER = 'parameters'
+    EXAMPLE = 'examples'
+    REQUEST_BODY = 'requestBodies'
+    HEADER = 'headers'
     SECURITY_SCHEMA = 'securitySchemes'
+    LINK = 'links'
+    CALLBACK = 'callbacks'
+    # OpenAPI 3.1.0+
+    PATH_ITEM = 'pathItems'
 
     def __init__(self, name, type, schema=None, object=None):
         self.name = name


### PR DESCRIPTION
Closes #1128 

The OpenAPI components object (https://swagger.io/specification/\#components-object) is used to store schema definitions that can be referred to using the
 pattern, encouraging re-use. drf-spectacular only uses the
'schemas' and 'securitySchemes' properties internally, but extension developers may wish to use the remaining properties, so they are provided as a convenience.

Note that the 'pathItems' property was added in OpenAPI 3.1.0.