### PR TITLE
Fix handling of metadata when using OAS 3.1 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,6 +63,3 @@ With that out of the way, we hope to hear from you soon.
 .. _blueprints: https://drf-spectacular.readthedocs.io/en/latest/blueprints.html
 .. _early feedback: https://github.com/tfranzel/drf-spectacular/issues
 .. _test_regressions.py: https://github.com/tfranzel/drf-spectacular/blob/master/tests/test_regressions.py
-
-
-

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -535,7 +535,7 @@ def append_meta(schema: _SchemaType, meta: _SchemaType) -> _SchemaType:
                 schema = {'oneOf': [schema, {'type': 'null'}]}
             elif len(schema) == 1 and 'oneOf' in schema:
                 schema['oneOf'].append({'type': 'null'})
-            elif not schema and not meta:
+            elif not schema:
                 schema = {'oneOf': [{}, {'type': 'null'}]}
             else:
                 assert False, 'Invalid nullable case'  # pragma: no cover

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3266,7 +3266,7 @@ def test_openapirequest_used_without_media_type_dict(no_warnings):
 @mock.patch('drf_spectacular.settings.spectacular_settings.OAS_VERSION', '3.1.0')
 def test_basic_oas_3_1_nullable_cases(no_warnings, django_transforms):
     class M14(models.Model):
-        field_json = models.JSONField(null=True)  # case 1
+        field_json = models.JSONField(null=True, help_text="field_json desc")  # case 1
 
     class XSerializer(serializers.ModelSerializer):
 
@@ -3286,7 +3286,7 @@ def test_basic_oas_3_1_nullable_cases(no_warnings, django_transforms):
     schema = generate_schema('m2', XViewset)
     assert schema['components']['schemas']['X']['properties'] == {
         'id': {'readOnly': True, 'type': 'integer'},
-        'field_json': {'oneOf': [{}, {'type': 'null'}]},
+        'field_json': {'oneOf': [{}, {'type': 'null'}], 'description': 'field_json desc'},
         'field_method_hint': {
             'oneOf': [
                 {'type': 'integer'},


### PR DESCRIPTION
Following https://github.com/tfranzel/drf-spectacular/issues/1133, still failing if there's some metadata set.

I don't know much about the internals of `drf-spectacular`, let me know if anything needs to be changed.