### PR TITLE
Optional setting for enum suffixes

### DIFF
--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -120,6 +120,9 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': True,
     # Add/Append a list of (``choice value`` - choice name) to the enum description string.
     'ENUM_GENERATE_CHOICE_DESCRIPTION': True,
+    # Optional suffix for generated enum.
+    # e.g. {'ENUM_SUFFIX': "Type"} would produce an enum name 'StatusType'.
+    'ENUM_SUFFIX': 'Enum',
 
     # function that returns a list of all classes that should be excluded from doc string extraction
     'GET_LIB_DOC_EXCLUDES': 'drf_spectacular.plumbing.get_lib_doc_excludes',

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -389,3 +389,22 @@ def test_equal_choices_different_semantics(no_warnings):
     assert schema['components']['schemas']['SomeTestEnum'] == {
         'enum': [0, 1], 'type': 'integer', 'description': '* `0` - test group A\n* `1` - test group B',
     }
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {
+    'VoteChoices': 'tests.test_postprocessing.vote_choices'
+})
+def test_enum_suffix(no_warnings, clear_caches):
+    """Test that enums generated have the suffix from the settings."""
+    # check variations of suffix
+    enum_suffix_variations = ['Type', 'Enum', 'Testing', '']
+    for variation in enum_suffix_variations:
+        with mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_SUFFIX', variation):
+            schema = generate_schema('a', AViewset)
+
+            assert f'Null{variation}' in schema['components']['schemas']
+            assert f'Blank{variation}' in schema['components']['schemas']
+            assert f'Language{variation}' in schema['components']['schemas']
+            # vote choices is overridden, so should not have the suffix added
+            assert f'Vote{variation}' not in schema['components']['schemas']
+            assert 'VoteChoices' in schema['components']['schemas']


### PR DESCRIPTION
Provide an `ENUM_SUFFIX` setting which allows for the option to define how enums will be named by default when automatically generated. This defaults to `Enum` to work with existing set ups. 

This does not affect enums named in `ENUM_NAME_OVERRIDE`. 