### PR TITLE
Fix builtin Swagger-UI OAuth login

### DIFF
--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -146,6 +146,9 @@ class SpectacularSwaggerView(APIView):
                 'schema_auth_names': self._dump(self._get_schema_auth_names()),
             },
             template_name=self.template_name,
+            headers={
+                "Cross-Origin-Opener-Policy": "unsafe-none",
+            }
         )
 
     def _dump(self, data):

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -151,6 +151,13 @@ def test_spectacular_ui_with_raw_settings(no_warnings):
 
 
 @pytest.mark.urls(__name__)
+def test_spectacular_ui_coop():
+    response = APIClient().get('/api/v2/schema/swagger-ui/')
+    assert response.status_code == 200
+    assert response["Cross-Origin-Opener-Policy"] == "unsafe-none"
+
+
+@pytest.mark.urls(__name__)
 def test_spectacular_ui_param_passthrough(no_warnings):
     response = APIClient().get('/api/v2/schema/swagger-ui/?foo=bar&lang=jp&version=v2')
     assert response.status_code == 200


### PR DESCRIPTION
This PR intends to fix an issue when using the OAuth authentication mechanism built into Swagger-UI. 

When using this mechanism, Swagger-UI authenticates against an OAuth provider on its own and then uses the retrieved access tokens for making requests to the django api. However this does not always work because Swagger-UI implements its authentication using two tabs and then accessing the initiating one via the [window.opener](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener) property. This property can be null under some circumstances. One of them is that the tab where the main Swagger-UI is open, sets a [Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) to a restrictive value. Django does the right thing (generally speaking) and sets it to such a restrictive value (see [django docs](https://docs.djangoproject.com/en/dev/ref/settings/#secure-cross-origin-opener-policy)).
This leads to errors as described in swagger-api/swagger-ui#8030.

This PR overwrites the required header for the Swagger-UI view only so that Swagger-UI can perform its authentication as intended.

---

*Side note*:  Choosing the value `same-origin-allow-popups` as COOP also works depending on the OAuth provider that someone is using. Since we cannot ensure that a compatible OAuth provider is used, I chose to go for increased compatibility and a little less security here since Swagger-UI is mainly used for dev setups and documentation anyways.