### PR TITLE
Update link to redoc settings

### DIFF
--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -72,7 +72,7 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'SWAGGER_UI_OAUTH2_CONFIG': {},
 
     # Dictionary of general configuration to pass to the Redoc.init({ ... })
-    # https://github.com/Redocly/redoc#redoc-options-object
+    # https://redocly.com/docs/redoc/config/#functional-settings
     # The settings are serialized with json.dumps(). If you need customized JS, use a
     # string instead. The string must then contain valid JS and is passed unchanged.
     'REDOC_UI_SETTINGS': {},


### PR DESCRIPTION
Link https://github.com/Redocly/redoc#redoc-options-object doesn't exist anymore. It was deleted after [this](https://github.com/Redocly/redoc/pull/2393) PR.

I found [settings](https://redocly.com/docs/redoc/config/#functional-settings) list for Redoc on their site. And suggest to use it. 