### PR TITLE
Update SWAGGER_UI_DIST settings.rst

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -56,7 +56,7 @@ in your project files.
             ...
         },
         # available SwaggerUI versions: https://github.com/swagger-api/swagger-ui/releases
-        "SWAGGER_UI_DIST": "//unpkg.com/swagger-ui-dist@3.35.1", # default
+        "SWAGGER_UI_DIST": "https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest", # default
         "SWAGGER_UI_FAVICON_HREF": settings.STATIC_URL + "your_company_favicon.png", # default is swagger favicon
         ...
     }


### PR DESCRIPTION
Small documentation fix, the settings documentation says that the default SWAGGER_UI_DIST is //unpkg.com/swagger-ui-dist@3.35.1 - but this seems to have changed, the default is now https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest