### PR TITLE
Add a specific Action Wrapper for OAuth Authorization requests #1190

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/swagger_ui.js
+++ b/drf_spectacular/templates/drf_spectacular/swagger_ui.js
@@ -10,6 +10,11 @@ const reloadSchemaOnAuthChange = () => {
     statePlugins: {
       auth: {
         wrapActions: {
+          authorizeOauth2:(ori) => (...args) => {
+            schemaAuthFailed = false;
+            setTimeout(() => ui.specActions.download());
+            return ori(...args);
+          },
           authorize: (ori) => (...args) => {
             schemaAuthFailed = false;
             setTimeout(() => ui.specActions.download());


### PR DESCRIPTION
So that the schema reloads after authorization

See issue #1190 