### PR TITLE
Add support for TypeAliasType

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -75,12 +75,17 @@ else:
 
 LITERAL_TYPES: Tuple[Any, ...] = ()
 TYPED_DICT_META_TYPES: Tuple[Any, ...] = ()
+TYPE_ALIAS_TYPES: Tuple[Any, ...] = ()
 
 if sys.version_info >= (3, 8):
     from typing import Literal as _PyLiteral
     from typing import _TypedDictMeta as _PyTypedDictMeta  # type: ignore[attr-defined]
     LITERAL_TYPES += (_PyLiteral,)
     TYPED_DICT_META_TYPES += (_PyTypedDictMeta,)
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+    TYPE_ALIAS_TYPES += (TypeAliasType,)
 
 try:
     from typing_extensions import Literal as _PxLiteral
@@ -1302,6 +1307,9 @@ def is_higher_order_type_hint(hint) -> bool:
 
 def resolve_type_hint(hint):
     """ resolve return value type hints to schema """
+    if isinstance(hint, TYPE_ALIAS_TYPES):
+        hint = hint.__value__
+    
     origin, args = _get_type_hint_origin(hint)
 
     if origin is None and is_basic_type(hint, allow_none=False):

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -1307,9 +1307,6 @@ def is_higher_order_type_hint(hint) -> bool:
 
 def resolve_type_hint(hint):
     """ resolve return value type hints to schema """
-    if isinstance(hint, TYPE_ALIAS_TYPES):
-        hint = hint.__value__
-    
     origin, args = _get_type_hint_origin(hint)
 
     if origin is None and is_basic_type(hint, allow_none=False):
@@ -1355,6 +1352,8 @@ def resolve_type_hint(hint):
         return schema
     elif isinstance(hint, TYPED_DICT_META_TYPES):
         return _resolve_typeddict(hint)
+    elif isinstance(hint, TYPE_ALIAS_TYPES):
+        return resolve_type_hint(hint.__value__)
     elif origin in UNION_TYPES:
         type_args = [arg for arg in args if arg is not type(None)]  # noqa: E721
         if len(type_args) > 1:

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -322,16 +322,16 @@ if sys.version_info >= (3, 10):
     ])
 
 if sys.version_info >= (3, 12):
-    type MyAlias = typing.Literal['x', 'y']
-    type MyAliasNested = MyAlias | list[int | str]
+    exec("type MyAlias = typing.Literal['x', 'y']")
+    exec("type MyAliasNested = MyAlias | list[int | str]")
 
     TYPE_HINT_TEST_PARAMS.extend([
         (
-            MyAlias,
+            MyAlias,  # noqa: F821
             {'enum': ['x', 'y'], 'type': 'string'}
         ),
         (
-            MyAliasNested,
+            MyAliasNested,  # noqa: F821
             {
                 'oneOf': [
                     {'enum': ['x', 'y'], 'type': 'string'},
@@ -340,6 +340,7 @@ if sys.version_info >= (3, 12):
             }
         )
     ])
+
 
 @pytest.mark.parametrize(['type_hint', 'ref_schema'], TYPE_HINT_TEST_PARAMS)
 def test_type_hint_extraction(no_warnings, type_hint, ref_schema):

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -321,6 +321,25 @@ if sys.version_info >= (3, 10):
         )
     ])
 
+if sys.version_info >= (3, 12):
+    type MyAlias = typing.Literal['x', 'y']
+    type MyAliasNested = MyAlias | list[int | str]
+
+    TYPE_HINT_TEST_PARAMS.extend([
+        (
+            MyAlias,
+            {'enum': ['x', 'y'], 'type': 'string'}
+        ),
+        (
+            MyAliasNested,
+            {
+                'oneOf': [
+                    {'enum': ['x', 'y'], 'type': 'string'},
+                    {"type": "array", "items": {"oneOf": [{"type": "integer"}, {"type": "string"}]}}
+                ]
+            }
+        )
+    ])
 
 @pytest.mark.parametrize(['type_hint', 'ref_schema'], TYPE_HINT_TEST_PARAMS)
 def test_type_hint_extraction(no_warnings, type_hint, ref_schema):


### PR DESCRIPTION
Its a new way to defined type aliases added in Python 3.12

Previous way is deprecated:
```
from typing import TypeAlias, Literal
MyType: TypeAlias = Literal["primary", "secondary"]
```

New way is:
```
type MyType = Literal["primary", "secondary"]
```
where is `MyType` is instance of https://docs.python.org/3/library/typing.html#typing.TypeAliasType
