### PR TITLE
Add support for stateless user authentication in SimpleJWT

### DIFF
--- a/drf_spectacular/contrib/rest_framework_simplejwt.py
+++ b/drf_spectacular/contrib/rest_framework_simplejwt.py
@@ -81,3 +81,7 @@ class SimpleJWTScheme(OpenApiAuthenticationExtension):
 
 class SimpleJWTTokenUserScheme(SimpleJWTScheme):
     target_class = 'rest_framework_simplejwt.authentication.JWTTokenUserAuthentication'
+
+
+class SimpleJWTStatelessUserScheme(SimpleJWTScheme):
+    target_class = "rest_framework_simplejwt.authentication.JWTStatelessUserAuthentication"

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -8,7 +8,7 @@ from tests import assert_schema, generate_schema
 
 try:
     from rest_framework_simplejwt.authentication import (
-        JWTAuthentication, JWTTokenUserAuthentication, JWTStatelessUserAuthentication
+        JWTAuthentication, JWTStatelessUserAuthentication, JWTTokenUserAuthentication
     )
     from rest_framework_simplejwt.views import (
         TokenObtainPairView, TokenObtainSlidingView, TokenRefreshView, TokenVerifyView,

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -33,6 +33,7 @@ class X2Viewset(mixins.ListModelMixin, viewsets.GenericViewSet):
     authentication_classes = [JWTTokenUserAuthentication]
     required_scopes = ['x:read', 'x:write']
 
+
 class X3Viewset(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = XSerializer
     authentication_classes = [JWTStatelessUserAuthentication]

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -8,7 +8,7 @@ from tests import assert_schema, generate_schema
 
 try:
     from rest_framework_simplejwt.authentication import (
-        JWTAuthentication, JWTTokenUserAuthentication,
+        JWTAuthentication, JWTTokenUserAuthentication, JWTStatelessUserAuthentication
     )
     from rest_framework_simplejwt.views import (
         TokenObtainPairView, TokenObtainSlidingView, TokenRefreshView, TokenVerifyView,
@@ -33,9 +33,14 @@ class X2Viewset(mixins.ListModelMixin, viewsets.GenericViewSet):
     authentication_classes = [JWTTokenUserAuthentication]
     required_scopes = ['x:read', 'x:write']
 
+class X3Viewset(mixins.ListModelMixin, viewsets.GenericViewSet):
+    serializer_class = XSerializer
+    authentication_classes = [JWTStatelessUserAuthentication]
+    required_scopes = ['x:read', 'x:write']
+
 
 @pytest.mark.contrib('rest_framework_simplejwt')
-@pytest.mark.parametrize('view', [XViewset, X2Viewset])
+@pytest.mark.parametrize('view', [XViewset, X2Viewset, X3Viewset])
 def test_simplejwt(no_warnings, view):
     router = routers.SimpleRouter()
     router.register('x', view, basename="x")

--- a/tests/contrib/test_simplejwt.py
+++ b/tests/contrib/test_simplejwt.py
@@ -8,7 +8,7 @@ from tests import assert_schema, generate_schema
 
 try:
     from rest_framework_simplejwt.authentication import (
-        JWTAuthentication, JWTStatelessUserAuthentication, JWTTokenUserAuthentication
+        JWTAuthentication, JWTStatelessUserAuthentication, JWTTokenUserAuthentication,
     )
     from rest_framework_simplejwt.views import (
         TokenObtainPairView, TokenObtainSlidingView, TokenRefreshView, TokenVerifyView,


### PR DESCRIPTION
Most SimpleJWT classes are supported in the OpenAPI spec, but the stateless user auth was missing. I've added it in this PR.
The stateless user auth is described here: https://django-rest-framework-simplejwt.readthedocs.io/en/latest/stateless_user_authentication.html