### PR TITLE
Do not wrap an example list value in another list

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -1408,18 +1408,18 @@ def build_mocked_view(method: str, path: str, extend_schema_decorator, registry)
 
 def build_listed_example_value(value: Any, paginator, direction):
     if not paginator or direction == 'request':
-        return [value]
+        return value if type(value) is list else [value]
 
     sentinel = object()
     schema = paginator.get_paginated_response_schema(sentinel)
 
     if schema is sentinel:
-        return [value]
+        return value if type(value) is list else [value]
 
     def drilldown_schema_example(schema, sentinel):
         # Recursively travel schema properties to build example.
         if schema is sentinel:
-            return [value]
+            return value if type(value) is list else [value]
         if 'properties' in schema.keys():
             return {
                 field_name: drilldown_schema_example(field_schema, sentinel)

--- a/tests/test_examples.yml
+++ b/tests/test_examples.yml
@@ -40,6 +40,11 @@ paths:
                   value:
                   - field: 111
                   summary: Serializer C Example RO
+                SerializerCExampleList:
+                  value:
+                  - field: 333
+                  - field: 444
+                  summary: Serializer C Example List
           description: ''
     post:
       operationId: schema_create


### PR DESCRIPTION
The purpose of this PR is to allow a list of values (more than one) to be presented as the _value_ of an Open API Example.  In all the examples I found online, only a single value is supplied, which value is automatically turned into a list.  Also, there are no unit tests for handling a list of values.

### Background
In 0.22.0, a change was made, reflected by the following entry in the release notes:

> Examples are now wrapped in pagination/lists when endpoint/serializer is many=True

Based on the following decorator...

    @extend_schema(
        examples = [
            OpenApiExample(
                "name",
                value={"pet": "dog"}
            ),
        ]
    )

...the Swagger example renders like this:

    [
      {
        "pet": "dog"
      }
    ]

So far, so good.

### The Problem
If a list is explicitly supplied for the example value, it is _still_ wrapped in a list.  Given the following...

    @extend_schema(
        examples = [
            OpenApiExample(
                "name",
                value=[
                    {"pet": "dog"}
                    {"pet": "cat"}
                ],
            ),
        ]
    )

...the Swagger example renders like this:

    [
      [
        {
          "pet": "dog"
        },
        {
          "pet": "cat"
        }
      ]
    ]

### The Expectation
I would expect the rendered example to not be nested in a list, for example:

    [
      {
        "pet": "dog"
      },
      {
        "pet": "cat"
      }
    ]

### The Solution
With the proposed changes, if a list is supplied as the value of an example, it is not wrapped in a new list.