### PR TITLE
Implement exclude_non_public_endpoints

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -306,6 +306,9 @@ additional hooks with the ``PREPROCESSING_HOOKS`` setting.
   :py:func:`drf_spectacular.hooks.preprocess_exclude_path_format <drf_spectacular.hooks.preprocess_exclude_path_format>`
   hook. You can simply enable this hook by adding the import path string to the ``PREPROCESSING_HOOKS``.
 
+.. note:: For excluding some operations from the schema, you can use the :py:func:`drf_spectacular.hooks.exclude_non_public_endpoints` hook.
+  This hook will exclude all operations that are not marked as public by the :py:func:`@extend_schema <drf_spectacular.utils.extend_schema>` decorator.
+
 Congratulations
 ---------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -349,6 +349,14 @@ not allowed. ``SpectacularAPIView`` has dedicated arguments for overriding these
         ), name='schema-custom'),
     ]
 
+How can I hide certain operations from the public and only show them to staff users
+-----------------------------------------------------------------------------------
+
+If you have a concrete list urls then the way to go is to define a route and pass ``urlconf`` to the ```SpectacularAPIView``` view.
+
+Otherwise you can add ``drf_spectacular.hooks.postprocess_exclude_non_public_endpoints`` to the ``POSTPROCESSING_HOOKS`` setting then add ``Public`` tag to the operations you want to be public, 
+other operations will be considered private and will be accessible only by staff users.
+
 How to correctly annotate function-based views that use ``@api_view()``
 -----------------------------------------------------------------------
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,60 @@
+from unittest.mock import Mock
+
+from drf_spectacular.hooks import postprocess_exclude_non_public_endpoints
+
+
+class TestPostProcessExcludeNonPublicEndpoints:
+    result = {
+        "paths": {
+            "/some/path/": {
+                "get": {"tags": ["Public", "Sign up"]},
+                "patch": {"tags": ["Clean up inactive users"]}
+            },
+            "/internal/some/path/": {
+                "get": {"tags": ["Internal"]}
+            },
+        }
+    }
+
+    def test_exclude_non_public_endpoints_for_anonymous_users(self):
+        request = Mock(user=Mock(is_staff=False, is_authenticated=False))
+        actual = postprocess_exclude_non_public_endpoints(self.result, None, request, True)
+        expected = {
+            "paths": {
+                "/some/path/": {
+                    "get": {"tags": ["Sign up"]},
+                },
+                "/internal/some/path/": {},
+            }
+        }
+        assert actual == expected
+
+    def test_exclude_non_public_endpoints_for_non_staff(self):
+        user = Mock(is_staff=False)
+        request = Mock(user=user)
+        actual = postprocess_exclude_non_public_endpoints(self.result, None, request, True)
+        expected = {
+            "paths": {
+                "/some/path/": {
+                    "get": {"tags": ["Sign up"]},
+                },
+                "/internal/some/path/": {},
+            }
+        }
+        assert actual == expected
+
+    def test_return_all_endpoints_for_staff(self):
+        request = Mock(user=Mock(is_staff=True))
+        actual = postprocess_exclude_non_public_endpoints(self.result, None, request, True)
+        expected = {
+            "paths": {
+                "/some/path/": {
+                    "get": {"tags": ["Sign up"]},
+                    "patch": {"tags": ["Clean up inactive users"]}
+                },
+                "/internal/some/path/": {
+                    "get": {"tags": ["Internal"]}
+                },
+            }
+        }
+        assert actual == expected


### PR DESCRIPTION
I think it's common to have some endpoints only for internal usage and you want to show them only to staff users.

I know that you can do it by defining separate view and setting `urlconf` but it comes with a few drawbacks

- a list of routes needs to be maintained in a separate module
- a separate view needs to be created which results in having to routes one for public access and one for staff users.

This pr introduces a hook and only shows endpoints with Public tag to non-staff users. the upsides

- a single view and route for serving docs
- it's more verbose as the operation has a Public tag