### PR TITLE
Correct the documentation of how to import extension snippets

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -14,10 +14,20 @@ Blueprint files can be found `here <https://github.com/tfranzel/drf-spectacular/
 
 .. note:: Simply copy&paste the snippets into your codebase. The extensions register
   themselves automatically. Just be sure that the python interpreter sees them at least once.
-  To that end, we suggest creating a ``PROJECT/schema.py`` file and importing it in your
-  ``PROJECT/__init__.py`` (same directory as ``settings.py`` and ``urls.py``)
-  with ``import PROJECT.schema``. Now you are all set.
+  It is good practice to collect your extensions in ``YOUR_MAIN_APP_NAME/schema.py`` and importing that
+  file in your ``YOUR_MAIN_APP_NAME/apps.py``. Every proper Django app will already have an auto-generated
+  ``apps.py`` file. Although not strictly necessary, doing the import in ``ready()`` is the most robust
+  approach. It will make sure your environment (e.g. settings) is properly set up prior to loading.
 
+.. code-block:: python
+
+    # your_main_app_name/apps.py
+    class YourMainAppNameConfig(AppConfig):
+        default_auto_field = "django.db.models.BigAutoField"
+        name = "your_main_app_name"
+
+        def ready(self):
+            import your_main_app_name.schema  # noqa: E402
 
 dj-stripe
 ---------


### PR DESCRIPTION
The method currently documented here (adding to `PROJECT/schema.py` and `PROJECT/__init__.py`) is too early, before the app is ready. Instead I copied the instructions at https://drf-spectacular.readthedocs.io/en/latest/customization.html#step-5-extensions which loads the extensions in the app's `ready()` method.

I literally copied the instructions text from customization step 5. You may want to remove this dupe and simply refer users to follow the step 5 instructions.

When using the approach of adding to `PROJECT/__init__.py` (or `YOUR_MAIN_APP_NAME/__initi__.py`) drf-spectacular throws an error because `DEFAULT_SCHEMA_CLASS` has not be properly initialized yet.

Here's an example of where I do this: https://github.com/columbia-it/django-jsonapi-training/blob/spectacular/myapp/apps.py

I hope this makes sense and thanks for this project!