### PR TITLE
No extra items in the oneOf list

### DIFF
--- a/drf_spectacular/contrib/rest_polymorphic.py
+++ b/drf_spectacular/contrib/rest_polymorphic.py
@@ -42,8 +42,13 @@ class PolymorphicSerializerExtension(OpenApiSerializerExtension):
                     f'this might lead to code generation issues.'
                 )
 
+        one_of_list = []
+        for _, ref in sub_components:
+            if ref not in one_of_list:
+                one_of_list.append(ref)
+
         return {
-            'oneOf': [ref for _, ref in sub_components],
+            'oneOf': one_of_list,
             'discriminator': {
                 'propertyName': serializer.resource_type_field_name,
                 'mapping': {resource_type: ref['$ref'] for resource_type, ref in sub_components},

--- a/drf_spectacular/serializers.py
+++ b/drf_spectacular/serializers.py
@@ -20,8 +20,12 @@ class PolymorphicProxySerializerExtension(OpenApiSerializerExtension):
         if not self._has_discriminator():
             return {'oneOf': [schema for _, schema in sub_components]}
         else:
+            one_of_list = []
+            for _, schema in sub_components:
+                if schema not in one_of_list:
+                    one_of_list.append(schema)
             return {
-                'oneOf': [schema for _, schema in sub_components],
+                'oneOf': one_of_list,
                 'discriminator': {
                     'propertyName': self.target.resource_type_field_name,
                     'mapping': {resource_type: schema['$ref'] for resource_type, schema in sub_components}


### PR DESCRIPTION
In case we want to map some different values to the same serializer:

```py
class XViewSet(viewsets.GenericViewSet):
    @extend_schema(
        responses=PolymorphicProxySerializer(
            component_name='MetaPerson',
            serializers={
                'natural': NaturalPersonSerializer,
                'basic': DefaultPersonSerializer,
                'simple': DefaultPersonSerializer,
            },
            resource_type_field_name='type',
        )
    )
```

We don't need extra items in the `oneOf` section like here:

```yaml
components:
  schemas:
    MetaPerson:
      oneOf:
      - $ref: '#/components/schemas/NaturalPerson'
      - $ref: '#/components/schemas/DefaultPerson'
      - $ref: '#/components/schemas/DefaultPerson' # extra item
      discriminator:
        propertyName: type
        mapping:
          natural: '#/components/schemas/NaturalPerson'
          basic: '#/components/schemas/DefaultPerson'
          simple: '#/components/schemas/DefaultPerson'
```

The expected result is:

```yaml
components:
  schemas:
    MetaPerson:
      oneOf:
      - $ref: '#/components/schemas/NaturalPerson'
      - $ref: '#/components/schemas/DefaultPerson'
      discriminator:
        propertyName: type
        mapping:
          natural: '#/components/schemas/NaturalPerson'
          basic: '#/components/schemas/DefaultPerson'
          simple: '#/components/schemas/DefaultPerson'
```