### PR TITLE
Add x-enumNames to Enum schema

### DIFF
--- a/drf_spectacular/hooks.py
+++ b/drf_spectacular/hooks.py
@@ -130,8 +130,10 @@ def postprocess_schema_enums(result, generator, **kwargs):
             enum_name = enum_name_mapping.get(prop_hash) or enum_name_mapping[prop_hash, prop_name]
 
             # split property into remaining property and enum component parts
-            enum_schema = {k: v for k, v in prop_schema.items() if k in ['type', 'enum']}
-            prop_schema = {k: v for k, v in prop_schema.items() if k not in ['type', 'enum', 'x-spec-enum-id']}
+            enum_schema = {k: v for k, v in prop_schema.items() if k in ['type', 'enum', 'x-enumNames']}
+            prop_schema = {
+                k: v for k, v in prop_schema.items() if k not in ['type', 'enum', 'x-spec-enum-id', 'x-enumNames']
+            }
 
             # separate actual description from name-value tuples
             if spectacular_settings.ENUM_GENERATE_CHOICE_DESCRIPTION:

--- a/tests/contrib/test_django_filters.yml
+++ b/tests/contrib/test_django_filters.yml
@@ -21,6 +21,9 @@ paths:
         name: category
         schema:
           type: string
+          x-enumNames:
+          - aaa
+          - b
           enum:
           - A
           - B
@@ -43,6 +46,9 @@ paths:
           type: array
           items:
             type: string
+            x-enumNames:
+            - aaa
+            - b
             enum:
             - A
             - B
@@ -65,6 +71,9 @@ paths:
           type: array
           items:
             type: string
+            x-enumNames:
+            - aaa
+            - b
             enum:
             - A
             - B
@@ -107,6 +116,9 @@ paths:
           type: array
           items:
             type: string
+            x-enumNames:
+            - aaa
+            - b
             enum:
             - A
             - B
@@ -129,6 +141,9 @@ paths:
         name: model_single_cat
         schema:
           type: string
+          x-enumNames:
+          - aaa
+          - b
           enum:
           - A
           - B
@@ -271,6 +286,9 @@ components:
       - A
       - B
       type: string
+      x-enumNames:
+      - aaa
+      - b
       description: |-
         * `A` - aaa
         * `B` - b

--- a/tests/contrib/test_rest_auth.yml
+++ b/tests/contrib/test_rest_auth.yml
@@ -163,6 +163,10 @@ paths:
   /rest-auth/registration/:
     post:
       operationId: rest_auth_registration_create
+      description: |-
+        Registers a new user.
+
+        Accepts the following POST parameters: username, email, password1, password2.
       tags:
       - rest-auth
       requestBody:
@@ -191,6 +195,10 @@ paths:
   /rest-auth/registration/resend-email/:
     post:
       operationId: rest_auth_registration_resend_email_create
+      description: |-
+        Resends another email to an unverified email.
+
+        Accepts the following POST parameter: email.
       tags:
       - rest-auth
       requestBody:
@@ -218,6 +226,10 @@ paths:
   /rest-auth/registration/verify-email/:
     post:
       operationId: rest_auth_registration_verify_email_create
+      description: |-
+        Verifies the email associated with the provided key.
+
+        Accepts the following POST parameter: key.
       tags:
       - rest-auth
       requestBody:

--- a/tests/contrib/test_rest_auth_token.yml
+++ b/tests/contrib/test_rest_auth_token.yml
@@ -163,6 +163,10 @@ paths:
   /rest-auth/registration/:
     post:
       operationId: rest_auth_registration_create
+      description: |-
+        Registers a new user.
+
+        Accepts the following POST parameters: username, email, password1, password2.
       tags:
       - rest-auth
       requestBody:
@@ -191,6 +195,10 @@ paths:
   /rest-auth/registration/resend-email/:
     post:
       operationId: rest_auth_registration_resend_email_create
+      description: |-
+        Resends another email to an unverified email.
+
+        Accepts the following POST parameter: email.
       tags:
       - rest-auth
       requestBody:
@@ -218,6 +226,10 @@ paths:
   /rest-auth/registration/verify-email/:
     post:
       operationId: rest_auth_registration_verify_email_create
+      description: |-
+        Verifies the email associated with the provided key.
+
+        Accepts the following POST parameter: key.
       tags:
       - rest-auth
       requestBody:

--- a/tests/test_basic.yml
+++ b/tests/test_basic.yml
@@ -212,6 +212,9 @@ components:
       - POP
       - ROCK
       type: string
+      x-enumNames:
+      - Pop
+      - Rock
       description: |-
         * `POP` - Pop
         * `ROCK` - Rock

--- a/tests/test_basic_oas_3_1.yml
+++ b/tests/test_basic_oas_3_1.yml
@@ -212,6 +212,9 @@ components:
       - POP
       - ROCK
       type: string
+      x-enumNames:
+      - Pop
+      - Rock
       description: |-
         * `POP` - Pop
         * `ROCK` - Rock

--- a/tests/test_extend_schema.yml
+++ b/tests/test_extend_schema.yml
@@ -273,6 +273,10 @@ paths:
               * `a` - a
               * `b` - b
               * `c` - c
+            x-enumNames:
+            - a
+            - b
+            - c
           default:
           - a
       - in: query
@@ -369,6 +373,9 @@ components:
       - a
       - b
       type: string
+      x-enumNames:
+      - a
+      - b
       description: |-
         * `a` - a
         * `b` - b
@@ -403,6 +410,10 @@ components:
       - b
       - c
       type: string
+      x-enumNames:
+      - a
+      - b
+      - c
       description: |-
         * `a` - a
         * `b` - b

--- a/tests/test_i18n.yml
+++ b/tests/test_i18n.yml
@@ -128,6 +128,9 @@ components:
       - car
       - bicycle
       type: string
+      x-enumNames:
+      - Auto
+      - Fahrrad
       description: |-
         * `car` - Auto
         * `bicycle` - Fahrrad

--- a/tests/test_oas31.py
+++ b/tests/test_oas31.py
@@ -55,6 +55,7 @@ def test_nullable_enum_resolution(no_warnings):
     assert schema['components']['schemas']['FooEnum'] == {
         'description': '* `A` - A\n* `B` - B',
         'enum': ['A', 'B'],
+        'x-enumNames': ['A', 'B'],
         'type': 'string',
     }
     assert schema['components']['schemas']['X'] == {

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -167,10 +167,10 @@ TYPE_HINT_TEST_PARAMS = [
         {'oneOf': [{'type': 'string'}, {'type': 'integer'}], 'nullable': True}
     ), (
         LanguageEnum,
-        {'enum': ['en', 'de'], 'type': 'string'}
+        {'enum': ['en', 'de'], 'x-enumNames': ['EN', 'DE'], 'type': 'string'}
     ), (
         InvalidLanguageEnum,
-        {'enum': ['en', 'de']}
+        {'enum': ['en', 'de'], 'x-enumNames': ['EN', 'DE']}
     ), (
         NamedTupleB,
         {
@@ -191,7 +191,7 @@ if DJANGO_VERSION > '3':
 
     TYPE_HINT_TEST_PARAMS.append((
         LanguageChoices,
-        {'enum': ['en', 'de'], 'type': 'string'}
+        {'enum': ['en', 'de'], 'x-enumNames': ['EN', 'DE'], 'type': 'string'}
     ))
 
 if sys.version_info >= (3, 7):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -381,13 +381,22 @@ def test_equal_choices_different_semantics(no_warnings):
     schema = generate_schema('x', view=XAPIView)
 
     assert schema['components']['schemas']['SomeHealthEnum'] == {
-        'enum': [0, 1], 'type': 'integer', 'description': '* `0` - Ok\n* `1` - Fail'
+        'enum': [0, 1],
+        'x-enumNames': ['Ok', 'Fail'],
+        'type': 'integer',
+        'description': '* `0` - Ok\n* `1` - Fail',
     }
     assert schema['components']['schemas']['SomeStatusEnum'] == {
-        'enum': [0, 1], 'type': 'integer', 'description': '* `0` - Green\n* `1` - Red'
+        'enum': [0, 1],
+        'x-enumNames': ['Green', 'Red'],
+        'type': 'integer',
+        'description': '* `0` - Green\n* `1` - Red',
     }
     assert schema['components']['schemas']['SomeTestEnum'] == {
-        'enum': [0, 1], 'type': 'integer', 'description': '* `0` - test group A\n* `1` - test group B',
+        'enum': [0, 1],
+        'x-enumNames': ['test_group_A', 'test_group_B'],
+        'type': 'integer',
+        'description': '* `0` - test group A\n* `1` - test group B',
     }
 
 

--- a/tests/test_postprocessing.yml
+++ b/tests/test_postprocessing.yml
@@ -70,6 +70,11 @@ components:
       - ru
       - cn
       type: string
+      x-enumNames:
+      - en
+      - es
+      - ru
+      - cn
       description: |-
         * `en` - en
         * `es` - es
@@ -84,6 +89,10 @@ components:
       - 0
       - -1
       type: integer
+      x-enumNames:
+      - Positive
+      - Neutral
+      - Negative
       description: |-
         * `1` - Positive
         * `0` - Neutral

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3157,8 +3157,8 @@ def test_disable_enum_description_generation(no_warnings):
 
     schema = generate_schema('/x', view=XView)
     assert schema['components']['schemas'] == {
-        'BarEnum': {'enum': ['A', 'B', 'C'], 'type': 'string'},
-        'FooEnum': {'enum': ['A', 'B'], 'type': 'string'},
+        'BarEnum': {'enum': ['A', 'B', 'C'], 'x-enumNames': ['a', 'b', 'c'], 'type': 'string'},
+        'FooEnum': {'enum': ['A', 'B'], 'x-enumNames': ['a', 'b'], 'type': 'string'},
         'X': {
             'type': 'object',
             'properties': {


### PR DESCRIPTION
Add `x-enumNames` to enums similarly to [NSwag](https://github.com/RicoSuter/NSwag).

## Motivation

I use django-simple-history that has enum of diff types (`+`=added, `-`=removed, `~`=changed) and [ng-openapi-gen](https://github.com/cyclosproject/ng-openapi-gen) for generating DTOs. The problem is, the generator generates the enum member names based on the value, but in this case it generates invalid enum, because the values are only special characters.

By adding the `x-enumNames` extension, the generator can use those.