### PR TITLE
add hook to exclude startswith paths

### DIFF
--- a/drf_spectacular/hooks.py
+++ b/drf_spectacular/hooks.py
@@ -208,3 +208,22 @@ def preprocess_exclude_path_format(endpoints, **kwargs):
         for path, path_regex, method, callback in endpoints
         if not (path.endswith(format_path) or path.endswith(format_path + '/'))
     ]
+
+
+def preprocess_exclude_paths_startswith(endpoints, **kwargs):
+    """
+        preprocessing hook that excludes enpoints starting with 
+        values in PATHS_STARTSWITH_TO_EXCLUDE spectacular_settings.
+    """
+
+    def check_startswith(path):
+        for to_exclude in spectacular_settings.PATHS_STARTSWITH_TO_EXCLUDE :
+            if path.startswith(to_exclude) or path.startswith('/' + to_exclude):
+                return True
+        return False
+    
+    return [
+        (path, path_regex, method, callback)
+        for path, path_regex, method, callback in endpoints
+        if not check_startswith(path)
+    ]

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -213,6 +213,10 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # Optional: MUST contain 'url', may contain "description"
     'EXTERNAL_DOCS': {},
 
+    # Optional: List of starting with paths for excluding endpoints 
+    # using drf_spectacular.hooks.preprocess_exclude_paths_startswith
+    'PATHS_STARTSWITH_TO_EXCLUDE': [],
+
     # Arbitrary specification extensions attached to the schema's info object.
     # https://swagger.io/specification/#specification-extensions
     'EXTENSIONS_INFO': {},


### PR DESCRIPTION
Hi, first of all: this project is amazing!

I started to use this project for the first time in these days, i'm integrating it in a Django project where i manage admin panel by Wagtail. Wagtail admin urls integrate by default some endpoints, that i didn't want, so i wrote an hook to exclude paths starting with the same prefix. 

I thought that this hook cloud be useful to be provided by default in drf-spectacular so I created this pull request :)

I created the hook to exclude enpoints starting with some values : ```preprocess_exclude_paths_startswith```, and added an attrubuite in ```spectacular_settings``` to set these values : ```PATHS_STARTSWITH_TO_EXCLUDE```.

I hope this can be useful :)