### PR TITLE
Add support for x-enumDescriptions extension

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -456,6 +456,9 @@ def build_choice_field(field) -> _SchemaType:
     if spectacular_settings.ENUM_GENERATE_CHOICE_DESCRIPTION:
         schema['description'] = build_choice_description_list(field.choices.items())
 
+    if spectacular_settings.ENUM_GENERATE_X_ENUM_DESCRIPTIONS:
+        schema['x-enumDescriptions'] = dict(field.choices)
+
     schema['x-spec-enum-id'] = list_hash([(k, v) for k, v in field.choices.items() if k not in ('', None)])
 
     return schema

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -120,6 +120,8 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': True,
     # Add/Append a list of (``choice value`` - choice name) to the enum description string.
     'ENUM_GENERATE_CHOICE_DESCRIPTION': True,
+    # Add x-enumDescriptions extension field to enum schemas.
+    'ENUM_GENERATE_X_ENUM_DESCRIPTIONS': False,
     # Optional suffix for generated enum.
     # e.g. {'ENUM_SUFFIX': "Type"} would produce an enum name 'StatusType'.
     'ENUM_SUFFIX': 'Enum',

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -5,6 +5,7 @@ import sys
 import typing
 from datetime import datetime
 from enum import Enum
+from unittest import mock
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -422,6 +423,18 @@ def test_choicefield_empty_choices():
     schema = build_choice_field(serializers.ChoiceField(choices=[], allow_blank=True, allow_null=True))
     assert schema['enum'] == ['', None]
     assert schema['type'] == 'string'
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_GENERATE_X_ENUM_DESCRIPTIONS', True)
+def test_choicefield_x_enumdescriptions():
+    schema = build_choice_field(serializers.ChoiceField(
+        [('bluepill', 'Blue Pill'), ('redpill', 'Red Pill')],
+        allow_null=True, allow_blank=True
+    ))
+    assert schema['x-enumDescriptions'] == {
+        'bluepill': 'Blue Pill',
+        'redpill': 'Red Pill',
+    }
 
 
 def test_safe_ref():


### PR DESCRIPTION
This adds support for the `x-enumDescriptions` OpenAPI extension field as documented here:
https://redocly.com/docs/realm/author/reference/openapi-extensions/x-enum-descriptions

Redoc and Scalar support this extension and provide a better UX than text-based descriptions.

The change is fully backward-compatible. I added a new boolean setting `ENUM_GENERATE_X_ENUM_DESCRIPTIONS` to enable this feature. Let me know if this makes sense for you.