### PR TITLE
Document Django 5.1 support in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Requirements
 ------------
 
 -  Python >= 3.7
--  Django (2.2, 3.2, 4.0, 4.1, 4.2, 5.0)
+-  Django (2.2, 3.2, 4.0, 4.1, 4.2, 5.0, 5.1)
 -  Django REST Framework (3.10.3, 3.11, 3.12, 3.13, 3.14, 3.15)
 
 Installation


### PR DESCRIPTION
Django 5.1 is already supported, so list it in the README.

- #1291
- #1297