### PR TITLE
Fix docs compile issue and update some old code

### DIFF
--- a/docs/blueprints/elements.py
+++ b/docs/blueprints/elements.py
@@ -10,16 +10,16 @@ from drf_spectacular.views import AUTHENTICATION_CLASSES
 
 
 class SpectacularElementsView(APIView):
-     renderer_classes = [TemplateHTMLRenderer]
-     permission_classes = spectacular_settings.SERVE_PERMISSIONS
-     authentication_classes = AUTHENTICATION_CLASSES
-     url_name = 'schema'
-     url = None
-     template_name = 'elements.html'
-     title = spectacular_settings.TITLE
+    renderer_classes = [TemplateHTMLRenderer]
+    permission_classes = spectacular_settings.SERVE_PERMISSIONS
+    authentication_classes = AUTHENTICATION_CLASSES
+    url_name = 'schema'
+    url = None
+    template_name = 'elements.html'
+    title = spectacular_settings.TITLE
 
-     @extend_schema(exclude=True)
-     def get(self, request, *args, **kwargs):
+    @extend_schema(exclude=True)
+    def get(self, request, *args, **kwargs):
         return Response(
             data={
                 'title': self.title,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ linkcheck_allowed_redirects = {
     r"^https://tox\.wiki/$": r"https://tox\.wiki/en/latest/$",
     r"^https://drf-spectacular\.readthedocs\.io/$": r"https://drf-spectacular\.readthedocs\.io/en/latest/$",
     r"^https://docs\.djangoproject\.com/en/stable/": r"^https://docs\.djangoproject\.com/en/\d+\.\d+/",
-    r"^https://github\.com/tfranzel/drf-spectacular/issues/\d+": "https://github\.com/tfranzel/drf-spectacular/pull/\d+",
+    r"^https://github\.com/tfranzel/drf-spectacular/issues/\d+": r"https://github\.com/tfranzel/drf-spectacular/pull/\d+",
 }
 
 linkcheck_ignore = [

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-from __future__ import print_function
 
 import os
 import subprocess

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 import os
 import re
 import shutil

--- a/tests/contrib/test_drf_nested_routers.py
+++ b/tests/contrib/test_drf_nested_routers.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from django.db import models
-from django.urls import include, re_path
+from django.urls import include, path
 from rest_framework import serializers, viewsets
 from rest_framework.routers import SimpleRouter
 
@@ -41,8 +41,8 @@ def _generate_nested_routers_schema(root_viewset, child_viewset):
     root_router.register(r'child', child_viewset, basename='child')
 
     urlpatterns = [
-        re_path(r'^', include(router.urls)),
-        re_path(r'^', include(root_router.urls)),
+        path('', include(router.urls)),
+        path('', include(root_router.urls)),
     ]
     return generate_schema(None, patterns=urlpatterns)
 

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -13,9 +13,8 @@ else:
 
 import pytest
 from django import __version__ as DJANGO_VERSION
-from django.conf.urls import include
 from django.db import models
-from django.urls import re_path
+from django.urls import include, path
 from django.utils.functional import lazystr
 from rest_framework import generics, serializers
 
@@ -95,7 +94,7 @@ def test_follow_field_source_forward_reverse(no_warnings):
 
 def test_detype_patterns_with_module_includes(no_warnings):
     detype_pattern(
-        pattern=re_path(r'^', include('tests.test_fields'))
+        pattern=path('', include('tests.test_fields'))
     )
 
 

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -201,14 +201,13 @@ if DJANGO_VERSION > '3':
         {'enum': ['en', 'de'], 'type': 'string'}
     ))
 
-if sys.version_info >= (3, 7):
-    TYPE_HINT_TEST_PARAMS.append((
-        typing.Iterable[NamedTupleA],
-        {
-            'type': 'array',
-            'items': {'type': 'object', 'properties': {'a': {}, 'b': {}}, 'required': ['a', 'b']}
-        }
-    ))
+TYPE_HINT_TEST_PARAMS.append((
+    typing.Iterable[NamedTupleA],
+    {
+        'type': 'array',
+        'items': {'type': 'object', 'properties': {'a': {}, 'b': {}}, 'required': ['a', 'b']}
+    }
+))
 
 if sys.version_info >= (3, 8):
     # Literal only works for python >= 3.8 despite typing_extensions, because it

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -119,8 +119,14 @@ class InvalidLanguageEnum(Enum):
     DE = 'de'
 
 
-TD1 = TypedDict('TD1', {"foo": int, "bar": typing.List[str]})
-TD2 = TypedDict('TD2', {"foo": str, "bar": typing.Dict[str, int]})
+class TD1(TypedDict):
+    foo: int
+    bar: typing.List[str]
+
+
+class TD2(TypedDict):
+    foo: str
+    bar: typing.Dict[str, int]
 
 
 TYPE_HINT_TEST_PARAMS = [

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -28,7 +28,7 @@ class TreeNodeSerializer(serializers.ModelSerializer):
         model = TreeNode
 
     def get_fields(self):
-        fields = super(TreeNodeSerializer, self).get_fields()
+        fields = super().get_fields()
         fields['children'] = TreeNodeSerializer(many=True)
         return fields
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -241,8 +241,8 @@ def test_free_form_responses(no_warnings):
             pass  # pragma: no cover
 
     generate_schema(None, patterns=[
-        re_path(r'^x$', XAPIView.as_view(), name='x'),
-        re_path(r'^y$', YAPIView.as_view(), name='y'),
+        path('x', XAPIView.as_view(), name='x'),
+        path('y', YAPIView.as_view(), name='y'),
     ])
 
 
@@ -260,7 +260,7 @@ def test_append_extra_components(no_warnings):
             pass  # pragma: no cover
 
     schema = generate_schema(None, patterns=[
-        re_path(r'^x$', XAPIView.as_view(), name='x'),
+        path('x', XAPIView.as_view(), name='x'),
     ])
     assert len(schema['components']['schemas']) == 2
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,9 +4,8 @@ from unittest import mock
 
 import pytest
 import yaml
-from django.conf.urls import include
 from django.db import models
-from django.urls import path, re_path
+from django.urls import include, path, re_path
 from rest_framework import generics, mixins, routers, serializers, viewsets
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework.versioning import AcceptHeaderVersioning, NamespaceVersioning, URLPathVersioning


### PR DESCRIPTION
This PR fixes an issue I found with the docs and updates some of the test code. It doesn't change any user facing code.

- Fixes indent and config issue in docs
- Removes some Python 2 code
- Removes check for Python < 3.7 from tests
- Update tests to use newer URL functions added in Django 2.0