### PR TITLE
Fix `OpenApiViewExtension` not providing view instance under `self.target`

### DIFF
--- a/drf_spectacular/extensions.py
+++ b/drf_spectacular/extensions.py
@@ -118,6 +118,13 @@ class OpenApiViewExtension(OpenApiGeneratorExtension['OpenApiViewExtension']):
         if hasattr(cls.target_class, 'cls'):
             cls.target_class = cls.target_class.cls
 
+    @classmethod
+    def get_match(cls, target) -> 'Optional[OpenApiViewExtension]':
+        for extension in sorted(cls._registry, key=lambda e: e.priority, reverse=True):
+            if extension._matches(target.cls):
+                return extension(target)
+        return None
+
     @abstractmethod
     def view_replacement(self) -> 'Type[APIView]':
         pass  # pragma: no cover

--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -126,7 +126,7 @@ class SchemaGenerator(BaseSchemaGenerator):
         decorating plain views like retrieve, this initialization logic is not running.
         Therefore forcefully set the schema if @extend_schema decorator was used.
         """
-        override_view = OpenApiViewExtension.get_match(callback.cls)
+        override_view = OpenApiViewExtension.get_match(callback)
         if override_view:
             original_cls = callback.cls
             callback.cls = override_view.view_replacement()


### PR DESCRIPTION
`OpenApiViewExtension` was not providing the view instance under `self.target` (as the class documentation states it should) but rather the view's class. This makes it impossible to write viewset extensions if you need to access the viewset's action configuration.

This PR fixes #1400