### PR TITLE
fix: correct port mapping for the container in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ Generate your schema with the CLI:
 .. code:: bash
 
     $ ./manage.py spectacular --color --file schema.yml
-    $ docker run -p 80:8080 -e SWAGGER_JSON=/schema.yml -v ${PWD}/schema.yml:/schema.yml swaggerapi/swagger-ui
+    $ docker run -p 8080:8080 -e SWAGGER_JSON=/schema.yml -v ${PWD}/schema.yml:/schema.yml swaggerapi/swagger-ui
 
 If you also want to validate your schema add the ``--validate`` flag. Or serve your schema directly
 from your API. We also provide convenience wrappers for ``swagger-ui`` or ``redoc``.


### PR DESCRIPTION
Swagger runs on 8080 inside the container by default, so 80:8080 404'd for me. This fixes it