### PR TITLE
Add support for Scalar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,7 @@ these static files as a separate optional package. Usage is as follows:
         'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
         'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
         'REDOC_DIST': 'SIDECAR',
+        'SCALAR_DIST': 'SIDECAR',
         # OTHER SETTINGS
     }
 

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,7 @@ from your API. We also provide convenience wrappers for ``swagger-ui`` or ``redo
         # Optional UI:
         path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
         path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+        path('api/schema/scalar/', SpectacularScalarView.as_view(url_name='schema'), name='scalar'),
     ]
 
 Usage

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -77,12 +77,19 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # string instead. The string must then contain valid JS and is passed unchanged.
     'REDOC_UI_SETTINGS': {},
 
-    # CDNs for swagger and redoc. You can change the version or even host your
+    # Dictionary of general configuration to pass to the Scalar.
+    # https://github.com/scalar/scalar/blob/main/documentation/configuration.md
+    # The settings are serialized with json.dumps(). If you need customized JS, use a
+    # string instead. The string must then contain valid JS and is passed unchanged.
+    'SCALAR_UI_SETTINGS': {},
+
+    # CDNs for swagger, redoc, and scalar. You can change the version or even host your
     # own depending on your requirements. For self-hosting, have a look at
     # the sidecar option in the README.
     'SWAGGER_UI_DIST': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest',
     'SWAGGER_UI_FAVICON_HREF': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/favicon-32x32.png',
     'REDOC_DIST': 'https://cdn.jsdelivr.net/npm/redoc@latest',
+    'SCALAR_DIST': 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
 
     # Append OpenAPI objects to path and components in addition to the generated objects
     'APPEND_PATHS': {},

--- a/drf_spectacular/templates/drf_spectacular/scalar.html
+++ b/drf_spectacular/templates/drf_spectacular/scalar.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+
+<head>
+    {% block head %}
+    <title>{{ title|default:"Scalar" }}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="{{ scalar_css }}">
+</head>
+
+<body>
+    {% block body %}
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+
+    {% if settings %}
+    <script id="api-reference" type="application/yaml" data-url="{{ schema_url }}"></script>
+    <script src="{{ scalar_standalone }}"></script>
+    <script>
+        const scalarSetting = {{ settings| safe }};
+        document.getElementById('api-reference').dataset.configuration = JSON.stringify(scalarSetting)
+    </script>
+    {% else %}
+    <script id="api-reference" type="application/yaml" data-url="{{ schema_url }}"></script>
+    <script src="{{ scalar_standalone }}"></script>
+    {% endif %}
+    {% endblock body %}
+</body>
+
+</html>

--- a/tests/contrib/test_drf_spectacular_sidecar.py
+++ b/tests/contrib/test_drf_spectacular_sidecar.py
@@ -20,6 +20,7 @@ BUNDLE_URL = "static/drf_spectacular_sidecar/swagger-ui-dist/swagger-ui-bundle.j
 @mock.patch('drf_spectacular.settings.spectacular_settings.SWAGGER_UI_DIST', 'SIDECAR')
 @mock.patch('drf_spectacular.settings.spectacular_settings.SWAGGER_UI_FAVICON_HREF', 'SIDECAR')
 @mock.patch('drf_spectacular.settings.spectacular_settings.REDOC_DIST', 'SIDECAR')
+@mock.patch('drf_spectacular.settings.spectacular_settings.SCALAR_DIST', 'SIDECAR')
 @pytest.mark.urls(__name__)
 @pytest.mark.contrib('drf_spectacular_sidecar')
 def test_sidecar_shortcut_urls_are_resolved(no_warnings):
@@ -28,6 +29,8 @@ def test_sidecar_shortcut_urls_are_resolved(no_warnings):
     assert b'"/static/drf_spectacular_sidecar/swagger-ui-dist/favicon-32x32.png"' in response.content
     response = APIClient().get('/api/schema/redoc/')
     assert b'"/static/drf_spectacular_sidecar/redoc/bundles/redoc.standalone.js"' in response.content
+    response = APIClient().get('/api/schema/scalar/')
+    assert b'"/static/drf_spectacular_sidecar/scalar/standalone.js"' in response.content
 
 
 @pytest.mark.contrib('drf_spectacular_sidecar')

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -14,7 +14,7 @@ from drf_spectacular.utils import extend_schema
 from drf_spectacular.validation import validate_schema
 from drf_spectacular.views import (
     SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerOauthRedirectView,
-    SpectacularSwaggerSplitView, SpectacularSwaggerView,
+    SpectacularSwaggerSplitView, SpectacularSwaggerView, SpectacularScalarView,
 )
 
 
@@ -39,6 +39,7 @@ urlpatterns_v2 = [
         name="swagger-oauth-redirect"),
     path('api/v2/schema/swagger-ui-alt/', SpectacularSwaggerSplitView.as_view(), name='swagger-alt'),
     path('api/v2/schema/redoc/', SpectacularRedocView.as_view(), name='redoc'),
+    path('api/v2/schema/scalar/', SpectacularScalarView.as_view(), name='scalar'),
 ]
 urlpatterns_v2.append(
     path('api/v2/schema/', SpectacularAPIView.as_view(urlconf=urlpatterns_v2), name='schema'),
@@ -110,7 +111,7 @@ def test_spectacular_view_accept_unknown(no_warnings):
     )
 
 
-@pytest.mark.parametrize('ui', ['redoc', 'swagger-ui'])
+@pytest.mark.parametrize('ui', ['redoc', 'swagger-ui', 'scalar'])
 @pytest.mark.urls(__name__)
 def test_spectacular_ui_view(no_warnings, ui):
     from drf_spectacular.settings import spectacular_settings
@@ -120,6 +121,9 @@ def test_spectacular_ui_view(no_warnings, ui):
     if ui == 'redoc':
         assert b'<title>Redoc</title>' in response.content
         assert spectacular_settings.REDOC_DIST.encode() in response.content
+    elif ui == 'scalar':
+        assert b'<title>Scalar</title>' in response.content
+        assert spectacular_settings.SCALAR_DIST.encode() in response.content
     else:
         assert b'<title>Swagger</title>' in response.content
         assert spectacular_settings.SWAGGER_UI_DIST.encode() in response.content


### PR DESCRIPTION
## Summary

- Add support for `Scalar`
- You can see samples in [Supabase API Docs](https://api.supabase.com/api/v1)

## Reference

- [Scalar official website](https://scalar.com)
- [GitHub - scalar/scalar](https://github.com/scalar/scalar)