### PR TITLE
Fix memory leak

### DIFF
--- a/drf_spectacular/generators.py
+++ b/drf_spectacular/generators.py
@@ -1,5 +1,6 @@
 import os
 import re
+import weakref
 
 from django.urls import URLPattern, URLResolver
 from rest_framework import views, viewsets
@@ -106,6 +107,7 @@ class SchemaGenerator(BaseSchemaGenerator):
         self.registry = ComponentRegistry()
         self.api_version = kwargs.pop('api_version', None)
         self.inspector = None
+        self.schemas_storage = []
         super().__init__(*args, **kwargs)
 
     def coerce_path(self, path, method, view):
@@ -179,7 +181,7 @@ class SchemaGenerator(BaseSchemaGenerator):
             ) + view_schema_class.__mro__
             action_schema_class = type('ExtendedRearrangedSchema', mro, {})
 
-        view.schema = action_schema_class()
+        self._set_schema_to_view(view, action_schema_class())
         return view
 
     def _initialise_endpoints(self):
@@ -291,3 +293,11 @@ class SchemaGenerator(BaseSchemaGenerator):
             result = hook(result=result, generator=self, request=request, public=public)
 
         return sanitize_result_object(normalize_result_object(result))
+
+    def _set_schema_to_view(self, view, schema):
+        # The 'schema' argument is used to store the schema and view instance in the global scope,
+        # as 'schema' is a descriptor. To facilitate garbage collection of these objects,
+        # we wrap the schema in a weak reference and store it within the SchemaGenerator instance to keep it alive.
+        # Thus, the lifetime of both the view and the schema is tied to the lifetime of the SchemaGenerator instance.
+        view.schema = weakref.proxy(schema)
+        self.schemas_storage.append(schema)


### PR DESCRIPTION
The main problem was here:
```python
view.schema = action_schema_class()
```

'schema' is a descriptor, so under the hood it's similar to:

```python
from rest_framework.views import APIView
APIView.__dict__['schema'].instance_schemas[view] = action_schema_class()
```

Despite instance_schemas being a WeakKeyDictionary, it's never cleaned up because the schema has a reference to the view instance. This means that instance_schemas keeps a record as long as its value is alive.

So, the solution is to wrap the schema in a weakref and store the reference to the schema in SchemaGenerator.

I ran load tests by calling the SpectacularAPIView API and took some Dozer screenshots (the graph shows the number of objects in memory over time).

Before the fix (the count of view and schema instances was increasing):
<img width="1622" alt="image" src="https://github.com/user-attachments/assets/ac27047a-8ca7-475a-a091-541498794ef1" />

After the fix (all objects are cleaned up after the API returns a response):
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/be1662bc-c918-446d-86ca-7163e96429d3" />


This PR fixes #597 