### PR TITLE
Add Scalar UI support as a third documentation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Features
     - Vendor specification extensions (``x-*``) in info, operations, parameters, components, and security schemes
     - Sane fallbacks
     - Sane ``operation_id`` naming (based on path)
-    - Schema serving with ``SpectacularAPIView`` (Redoc and Swagger-UI views are also available)
+    - Schema serving with ``SpectacularAPIView`` (Redoc, Swagger-UI, and Scalar views are also available)
     - Optional input/output serializer component split
     - Callback operations
     - OpenAPI 3.1 support (via setting ``OAS_VERSION``)
@@ -113,7 +113,7 @@ Self-contained UI installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Certain environments have no direct access to the internet and as such are unable
-to retrieve Swagger UI or Redoc from CDNs. `drf-spectacular-sidecar`_ provides
+to retrieve Swagger UI, Redoc, or Scalar from CDNs. `drf-spectacular-sidecar`_ provides
 these static files as a separate optional package. Usage is as follows:
 
 .. code:: bash
@@ -131,6 +131,7 @@ these static files as a separate optional package. Usage is as follows:
         'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
         'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
         'REDOC_DIST': 'SIDECAR',
+        'SCALAR_DIST': 'SIDECAR',
         # OTHER SETTINGS
     }
 
@@ -162,17 +163,18 @@ Generate your schema with the CLI:
     $ docker run -p 8080:8080 -e SWAGGER_JSON=/schema.yml -v ${PWD}/schema.yml:/schema.yml swaggerapi/swagger-ui
 
 If you also want to validate your schema add the ``--validate`` flag. Or serve your schema directly
-from your API. We also provide convenience wrappers for ``swagger-ui`` or ``redoc``.
+from your API. We also provide convenience wrappers for ``swagger-ui``, ``redoc``, and ``scalar``.
 
 .. code:: python
 
-    from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+    from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView, SpectacularScalarView
     urlpatterns = [
         # YOUR PATTERNS
         path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
         # Optional UI:
         path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
         path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+        path('api/schema/scalar/', SpectacularScalarView.as_view(url_name='schema'), name='scalar'),
     ]
 
 Usage

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -63,6 +63,21 @@ Solution for Redoc:
     CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "fonts.googleapis.com")
     CSP_FONT_SRC = ("'self'", "fonts.gstatic.com")
 
+Solution for Scalar UI:
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    # Option: SIDECAR
+    SPECTACULAR_SETTINGS = {
+         ...
+        'SCALAR_DIST': 'SIDECAR',
+    }
+    CSP_DEFAULT_SRC = ("'self'", "'unsafe-inline'")
+
+    # Option: CDN
+    CSP_DEFAULT_SRC = ("'self'", "'unsafe-inline'", "cdn.jsdelivr.net")
+
 I cannot use :py:func:`@extend_schema <drf_spectacular.utils.extend_schema>` on library code
 --------------------------------------------------------------------------------------------
 
@@ -277,7 +292,7 @@ My ``@action`` is erroneously paginated or has filter parameters that I do not w
 This usually happens when ``@extend_schema(responses=XSerializer(many=True))`` is used. Actions inherit filter
 and pagination classes from their ``ViewSet``. If the response is then marked as a list, the ``pagination_class``
 kicks in. Since actions are handled manually by the user, this behavior is usually not immediately obvious.
-To make your intentions clear to *drf-spectacular*, you need to clear the offending classes in the action
+To make your intentions clear to *drf-spectacular*, you can clear the offending classes in the action
 decorator, e.g. setting ``pagination_class=None``.
 
 Users of *django-filter* might also see unwanted query parameters. Since the same mechanics apply here too,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ your schema and therefore your documentation & client will always stay close to 
 
 drf-spectacular works well out of the box, but also provides you with several easy ways
 to customize the generated OpenAPI 3 schema. It is explicitly designed to work well for
-documentation (`SwaggerUI <https://swagger.io/tools/swagger-ui>`_, `ReDoc <https://github.com/Redocly/redoc>`_)
+documentation (`SwaggerUI <https://swagger.io/tools/swagger-ui>`_, `ReDoc <https://github.com/Redocly/redoc>`_, `Scalar <https://github.com/scalar/scalar>`_)
 and automatic `client generation <https://openapi-generator.tech>`_.
 
 Table of Contents

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -77,12 +77,19 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # string instead. The string must then contain valid JS and is passed unchanged.
     'REDOC_UI_SETTINGS': {},
 
+    # Dictionary of general configuration to pass to the Scalar.createApiReference('#dom', { ... })
+    # https://github.com/scalar/scalar/blob/main/documentation/configuration.md
+    # The settings are serialized with json.dumps(). If you need customized JS, use a
+    # string instead. The string must then contain valid JS and is passed unchanged.
+    'SCALAR_UI_SETTINGS': {},
+
     # CDNs for swagger and redoc. You can change the version or even host your
     # own depending on your requirements. For self-hosting, have a look at
     # the sidecar option in the README.
     'SWAGGER_UI_DIST': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest',
     'SWAGGER_UI_FAVICON_HREF': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/favicon-32x32.png',
     'REDOC_DIST': 'https://cdn.jsdelivr.net/npm/redoc@latest',
+    'SCALAR_DIST': 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest',
 
     # Append OpenAPI objects to path and components in addition to the generated objects
     'APPEND_PATHS': {},

--- a/drf_spectacular/templates/drf_spectacular/scalar.html
+++ b/drf_spectacular/templates/drf_spectacular/scalar.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    {% block head %}
+    <title>{{ title|default:"Scalar" }}</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+    {% endblock head %}
+  </head>
+
+  <body>
+    {% block body %}
+    <div id="scalar-container"></div>
+
+    <!-- Load the Script -->
+    <script src="{{ scalar_standalone }}"></script>
+
+    <!-- Initialize the Scalar API Reference -->
+    <script>
+      const scalarSettings = {{ settings|safe }};
+      Scalar.createApiReference('#scalar-container', {
+        // The URL of the OpenAPI/Swagger document
+        url: "{{ schema_url }}",
+        ...scalarSettings
+      })
+    </script>
+    {% endblock body %}
+  </body>
+</html>

--- a/drf_spectacular/views.py
+++ b/drf_spectacular/views.py
@@ -301,8 +301,7 @@ class SpectacularScalarView(APIView):
         )
 
     def _dump(self, data):
-        if not data:
-            data = {}
+        data = data or {}
         return json.dumps(data, indent=2)
 
     @staticmethod

--- a/tests/contrib/test_drf_spectacular_sidecar.py
+++ b/tests/contrib/test_drf_spectacular_sidecar.py
@@ -6,12 +6,15 @@ import pytest
 from django.urls import path
 from rest_framework.test import APIClient
 
-from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+from drf_spectacular.views import (
+    SpectacularAPIView, SpectacularRedocView, SpectacularScalarView, SpectacularSwaggerView,
+)
 
 urlpatterns = [
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(), name='swagger'),
     path('api/schema/redoc/', SpectacularRedocView.as_view(), name='redoc'),
+    path('api/schema/scalar/', SpectacularScalarView.as_view(), name='scalar'),
 ]
 
 BUNDLE_URL = "static/drf_spectacular_sidecar/swagger-ui-dist/swagger-ui-bundle.js"
@@ -20,6 +23,7 @@ BUNDLE_URL = "static/drf_spectacular_sidecar/swagger-ui-dist/swagger-ui-bundle.j
 @mock.patch('drf_spectacular.settings.spectacular_settings.SWAGGER_UI_DIST', 'SIDECAR')
 @mock.patch('drf_spectacular.settings.spectacular_settings.SWAGGER_UI_FAVICON_HREF', 'SIDECAR')
 @mock.patch('drf_spectacular.settings.spectacular_settings.REDOC_DIST', 'SIDECAR')
+@mock.patch('drf_spectacular.settings.spectacular_settings.SCALAR_DIST', 'SIDECAR')
 @pytest.mark.urls(__name__)
 @pytest.mark.contrib('drf_spectacular_sidecar')
 def test_sidecar_shortcut_urls_are_resolved(no_warnings):
@@ -28,6 +32,8 @@ def test_sidecar_shortcut_urls_are_resolved(no_warnings):
     assert b'"/static/drf_spectacular_sidecar/swagger-ui-dist/favicon-32x32.png"' in response.content
     response = APIClient().get('/api/schema/redoc/')
     assert b'"/static/drf_spectacular_sidecar/redoc/bundles/redoc.standalone.js"' in response.content
+    response = APIClient().get('/api/schema/scalar/')
+    assert b'"/static/drf_spectacular_sidecar/@scalar/api-reference/dist/browser/standalone.js"' in response.content
 
 
 @pytest.mark.contrib('drf_spectacular_sidecar')

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -13,8 +13,8 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.validation import validate_schema
 from drf_spectacular.views import (
-    SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerOauthRedirectView,
-    SpectacularSwaggerSplitView, SpectacularSwaggerView,
+    SpectacularAPIView, SpectacularRedocView, SpectacularScalarView,
+    SpectacularSwaggerOauthRedirectView, SpectacularSwaggerSplitView, SpectacularSwaggerView,
 )
 
 
@@ -39,6 +39,7 @@ urlpatterns_v2 = [
         name="swagger-oauth-redirect"),
     path('api/v2/schema/swagger-ui-alt/', SpectacularSwaggerSplitView.as_view(), name='swagger-alt'),
     path('api/v2/schema/redoc/', SpectacularRedocView.as_view(), name='redoc'),
+    path('api/v2/schema/scalar/', SpectacularScalarView.as_view(), name='scalar'),
 ]
 urlpatterns_v2.append(
     path('api/v2/schema/', SpectacularAPIView.as_view(urlconf=urlpatterns_v2), name='schema'),
@@ -110,7 +111,7 @@ def test_spectacular_view_accept_unknown(no_warnings):
     )
 
 
-@pytest.mark.parametrize('ui', ['redoc', 'swagger-ui'])
+@pytest.mark.parametrize('ui', ['redoc', 'swagger-ui', 'scalar'])
 @pytest.mark.urls(__name__)
 def test_spectacular_ui_view(no_warnings, ui):
     from drf_spectacular.settings import spectacular_settings
@@ -120,6 +121,9 @@ def test_spectacular_ui_view(no_warnings, ui):
     if ui == 'redoc':
         assert b'<title>Redoc</title>' in response.content
         assert spectacular_settings.REDOC_DIST.encode() in response.content
+    elif ui == 'scalar':
+        assert b'<title>Scalar</title>' in response.content
+        assert spectacular_settings.SCALAR_DIST.encode() in response.content
     else:
         assert b'<title>Swagger</title>' in response.content
         assert spectacular_settings.SWAGGER_UI_DIST.encode() in response.content


### PR DESCRIPTION
## Implement #1426

Adds Scalar as a third documentation UI option alongside SwaggerUI and ReDoc.

**Usage:**
```python
from drf_spectacular.views import SpectacularScalarView

urlpatterns = [
    path('api/schema/scalar/', SpectacularScalarView.as_view(url_name='schema'), name='scalar'),
]
```