### PR TITLE
Add typing.Generic to default lib_doc_excludes

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -200,6 +200,7 @@ def get_lib_doc_excludes():
     return [
         object,
         dict,
+        Generic,
         views.APIView,
         *[getattr(serializers, c) for c in dir(serializers) if c.endswith('Serializer')],
         *[getattr(viewsets, c) for c in dir(viewsets) if c.endswith('ViewSet')],

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -21,7 +21,7 @@ from rest_framework import generics, serializers
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import (
     analyze_named_regex_pattern, build_basic_type, build_choice_field, detype_pattern,
-    follow_field_source, force_instance, get_list_serializer, get_relative_url, is_field,
+    follow_field_source, force_instance, get_doc, get_list_serializer, get_relative_url, is_field,
     is_serializer, resolve_type_hint, safe_ref, set_query_parameters,
 )
 from drf_spectacular.validation import validate_schema
@@ -452,3 +452,13 @@ def test_url_tooling_with_lazy_url():
 
     assert get_relative_url(lazystr(some_url)) == "/accounts/"
     assert set_query_parameters(lazystr(some_url), foo=123) == some_url + "?foo=123"
+
+
+def test_get_doc():
+    T = typing.TypeVar('T')
+
+    class MyClass(typing.Generic[T]):
+        pass
+
+    doc = get_doc(MyClass)
+    assert doc == ""


### PR DESCRIPTION
Since python 3.12 generic classes implicitly inherit from typing.Generic.

Googling `"On Python 3.12 and newer, generic classes implicitly inherit from Generic" ` turns up some docs that unintentionally include this doc-string:
https://github.com/python/cpython/blob/34ce1920ca33c11ca2c379ed0ef30a91010bef4f/Objects/typevarobject.c#L2188

