### PR TITLE
fix: sort list to produce same hash

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -939,7 +939,7 @@ def _load_enum_name_overrides(language: str):
 
 
 def list_hash(lst: Any) -> str:
-    return hashlib.sha256(json.dumps(list(lst), sort_keys=True, cls=JSONEncoder).encode()).hexdigest()[:16]
+    return hashlib.sha256(json.dumps(sorted(lst), sort_keys=True, cls=JSONEncoder).encode()).hexdigest()[:16]
 
 
 def anchor_pattern(pattern: str) -> str:

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -316,6 +316,21 @@ def test_enum_override_variations_with_blank_and_null(no_warnings):
             assert list_hash(expected_hashed_keys) in load_enum_name_overrides()
 
 
+def test_unsorted_enum(no_warnings):
+    enum_override_variations = [
+        ('LanguageEnum', [('fr', 'FR'), ('en', 'EN'), ('es', 'ES')]),
+        ('LanguageStrEnum', [('en', 'EN'), ('es', 'ES'), ('fr', 'FR')]),
+    ]
+
+    for variation, expected_hashed_keys in enum_override_variations:
+        with mock.patch(
+            'drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES',
+            {'LanguageEnum': [('es', 'ES'), ('en', 'EN'), ('fr', 'FR')]}
+        ):
+            _load_enum_name_overrides.cache_clear()
+            assert list_hash(expected_hashed_keys) in load_enum_name_overrides()
+
+
 @mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {
     'LanguageEnum': 'tests.test_postprocessing.NOTEXISTING'
 })


### PR DESCRIPTION
Hi :wave: 

This PR ensures that the list passed to `list_hash` is sorted before hashing. This change guarantees same hashes for equivalent data.

## Problem

When using enum/choice definitions like:
```python
[('fr', 'FR'), ('en', 'EN'), ('es', 'ES')]
[('en', 'EN'), ('es', 'ES'), ('fr', 'FR')]
[('es', 'ES'), ('en', 'EN'), ('fr', 'FR')]
```
the resulting hash from `list_hash` could vary depending on the order of items in the list. This inconsistency may lead to issues where a corresponding entry in `ENUM_NAME_OVERRIDES` is not recognized or only partially applied.