### PR TITLE
Implement x-spec-enum-id for type hint Choices.

### DIFF
--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -1389,6 +1389,8 @@ def resolve_type_hint(hint):
         mixin_base_types = [t for t in hint.__mro__ if is_basic_type(t)]
         if mixin_base_types:
             schema.update(build_basic_type(mixin_base_types[0]))
+        if issubclass(hint, Choices):
+            schema['x-spec-enum-id'] = list_hash([(k, v) for k, v in hint.choices if k not in ('', None)])
         return schema
     elif isinstance(hint, TYPED_DICT_META_TYPES):
         return _resolve_typeddict(hint)

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -197,7 +197,7 @@ if DJANGO_VERSION > '3':
 
     TYPE_HINT_TEST_PARAMS.append((
         LanguageChoices,
-        {'enum': ['en', 'de'], 'type': 'string'}
+        {'enum': ['en', 'de'], 'type': 'string', 'x-spec-enum-id': '982ab9eaa2725610'}
     ))
 
 TYPE_HINT_TEST_PARAMS.append((


### PR DESCRIPTION
This adds the `x-spec-enum-id` property to `Choices` type hints to enable correct handling in `postprocess_schema_enums`, using the `ENUM_NAME_OVERRIDES` declarations.
I'm not sure if additional tests are needed, let me know. Also, it may be cleaner to merge this with `build_choice_field`. I can implement that if it's acceptable.