### PR TITLE
Fix allow_blank CharField format fields rejecting empty strings

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1148,6 +1148,19 @@ class AutoSchema(ViewInspector):
                 elif isinstance(v, validators.MinLengthValidator):
                     update_constraint(schema, 'minProperties', max, v.limit_value)
 
+        # For format-constrained string fields (e.g. EmailField) with allow_blank=True,
+        # add an anyOf with the empty string option.
+        # Runs after validators so constraints like maxLength are already applied.
+        if (
+            getattr(field, 'allow_blank', False)
+            and schema_type == 'string'
+            and 'format' in schema
+        ):
+            # Keep readOnly/writeOnly/nullable etc. at the outer anyOf level.
+            outer_keys = {'readOnly', 'writeOnly', 'nullable', 'deprecated', 'description', 'title'}
+            inner = {k: schema.pop(k) for k in list(schema) if k not in outer_keys}
+            schema['anyOf'] = [inner, {'type': 'string', 'maxLength': 0}]
+
     def _map_response_type_hint(self, method):
         hint = get_override(method, 'field') or get_type_hints(method).get('return')
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -385,7 +385,10 @@ def test_serializer_with_dynamic_fields(no_warnings):
             'pattern': '^[\\w.@+-]+$',
             'maxLength': 150
         },
-        'email': {'type': 'string', 'format': 'email', 'title': 'Email address', 'maxLength': 254}
+        'email': {
+            'title': 'Email address',
+            'anyOf': [{'type': 'string', 'format': 'email', 'maxLength': 254}, {'type': 'string', 'maxLength': 0}]
+        }
     }
     assert schema['components']['schemas']['CompactUser']['properties'] == {
         'id': {'type': 'integer', 'readOnly': True}


### PR DESCRIPTION
CharField subclasses with a string format (EmailField, URLField, etc) and allow_blank=True can return "" as a valid response value, but the generated schema's format constraint (e.g. format: email, format: uri) rejects empty strings.

Fix by wrapping the schema in an anyOf with the original field information + `{type: string, maxLength: 0}` as the second option at the end of `_insert_field_validators`, after all field validators (including MaxLengthValidator) have been applied.

This preserves format validation for non-blank values while correctly allowing "" for fields where allow_blank=True. Outer-level schema metadata (readOnly, writeOnly, nullable, deprecated, title, description) is kept at the anyOf container level.

Fixes #909 