### PR TITLE
Fix nullable FileField response schema when blank=True (#1493)

### DIFF
--- a/drf_spectacular/openapi.py
+++ b/drf_spectacular/openapi.py
@@ -1003,6 +1003,14 @@ class AutoSchema(ViewInspector):
         if field.allow_null:
             # this will be converted later in case of OAS 3.1
             meta['nullable'] = True
+        elif (
+            isinstance(field, serializers.FileField)
+            and direction == 'response'
+            and not field.required
+        ):
+            # FileField.to_representation returns None for empty values regardless of
+            # allow_null, so blank=True / required=False model fields produce null responses.
+            meta['nullable'] = True
         if isinstance(field, serializers.CharField) and not field.allow_blank:
             # blank check only applies to inbound requests
             if spectacular_settings.COMPONENT_SPLIT_REQUEST:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -797,6 +797,46 @@ def test_file_field_duality_on_split_request(no_warnings):
     assert schema['components']['schemas']['XRequest']['properties']['file']['format'] == 'binary'
 
 
+def test_file_field_blank_is_nullable_in_response(no_warnings):
+    class M1493(models.Model):
+        document = models.FileField(blank=True)
+        required_doc = models.FileField()
+
+    class M1493Serializer(serializers.ModelSerializer):
+        class Meta:
+            model = M1493
+            fields = ['document', 'required_doc']
+
+    class M1493View(generics.RetrieveAPIView):
+        serializer_class = M1493Serializer
+        queryset = M1493.objects.none()
+
+    schema = generate_schema('/x', view=M1493View)
+    props = schema['components']['schemas']['M1493']['properties']
+    # FileField(blank=True) returns None from to_representation for empty values
+    assert props['document'] == {'type': 'string', 'format': 'uri', 'nullable': True}
+    # required FileField stays non-nullable
+    assert props['required_doc'] == {'type': 'string', 'format': 'uri'}
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.COMPONENT_SPLIT_REQUEST', True)
+def test_file_field_blank_nullable_only_in_response_on_split_request(no_warnings):
+    class XSerializer(serializers.Serializer):
+        file = serializers.FileField(required=False)
+
+    class XView(generics.ListCreateAPIView):
+        serializer_class = XSerializer
+        parser_classes = [parsers.MultiPartParser]
+
+    schema = generate_schema('/x', view=XView)
+    response_file = schema['components']['schemas']['X']['properties']['file']
+    request_file = schema['components']['schemas']['XRequest']['properties']['file']
+    # response can be null because DRF's FileField returns None for empty values
+    assert response_file.get('nullable') is True
+    # request side should not be marked nullable (allow_null is False)
+    assert 'nullable' not in request_file
+
+
 @mock.patch('drf_spectacular.settings.spectacular_settings.COMPONENT_SPLIT_REQUEST', True)
 def test_component_split_nested_ro_wo_serializer(no_warnings):
     class RoSerializer(serializers.Serializer):


### PR DESCRIPTION
When a model has `FileField(blank=True)`, DRF builds the serializer field with `required=False` but `allow_null=False`. However, `FileField.to_representation` returns `None` for empty values regardless of `allow_null`, so the response can be null even though the schema didn't mark it that way. 
  
This patch adds `nullable: true` to the response schema for non-required FileFields. Request schemas are unaffected (DRF still rejects null on input unless `allow_null=True` is explicitly set).
  
Added two regression tests in `tests/test_regressions.py`:
- `test_file_field_blank_is_nullable_in_response`: covers the exact `FileField(blank=True)` model case from the issue.
- `test_file_field_blank_nullable_only_in_response_on_split_request`: verifies request schemas don't get marked nullable under `COMPONENT_SPLIT_REQUEST`.