### PR TITLE
Document `django-rest-knox` support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Features
         - `djangorestframework-dataclasses <https://github.com/oxan/djangorestframework-dataclasses>`_
         - `django-rest-framework-gis <https://github.com/openwisp/django-rest-framework-gis>`_
         - `Pydantic (>=2.0) <https://github.com/pydantic/pydantic>`_
+        - `django-rest-knox <https://github.com/jazzband/django-rest-knox>`_
 
 
 For more information visit the `documentation <https://drf-spectacular.readthedocs.io/>`_.


### PR DESCRIPTION
Support for `django-rest-knox` was added in

- #1163

This PR documents that support to make it more discoverable to users.