### PR TITLE
Add ENUM_NAME_FROM_CLASS to name enums after their class

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -160,6 +160,42 @@ For example:
 If you have multiple semantically distinct enums that happen to have the same
 set of values, and you want different names for them, this mechanism won't work.
 
+Alternatively, rather than naming each enum by hand, you can have *drf-spectacular*
+name every enum after the ``models.Choices`` or ``Enum`` class that backs it, just
+like components are already named after their serializer class. Enable
+:ref:`ENUM_NAME_FROM_CLASS <settings>`:
+
+.. code-block:: python
+
+    SPECTACULAR_SETTINGS = {
+        ...
+        'ENUM_NAME_FROM_CLASS': True,
+    }
+
+With this, a field backed by ``class Priority(models.IntegerChoices)`` produces the
+component ``PriorityEnum`` regardless of the field name, and an enum reached through a
+type hint (e.g. a ``SerializerMethodField`` annotated with
+``@extend_schema_field(MyEnum)``) becomes ``MyEnum``. No per-enum entries and no field
+renames are needed, and explicit ``ENUM_NAME_OVERRIDES`` still take precedence.
+
+Field choices are matched to a ``models.Choices`` subclass by their set of choices, since
+DRF's ``ChoiceField`` only retains the choices (values and labels), not the class. A plain
+``Enum`` used directly as field choices is therefore only named after its class when it is
+also reached through a type hint.
+
+As with the default mechanism, some situations cannot be resolved automatically. Each
+emits a warning and falls back to the field-name resolution described above, of two
+kinds:
+
+* two distinct classes with the same set of choices, where the name cannot be
+  inferred from the values alone.
+* two distinct classes that share a class name but back different sets of choices
+  (as can happen across apps). Naming both after the class would collapse them into a
+  single component, so neither claims the name.
+
+In both cases, add an ``ENUM_NAME_OVERRIDES`` entry to give the affected enums an
+explicit name.
+
 My endpoints use different serializers depending on the situation
 -----------------------------------------------------------------
 

--- a/drf_spectacular/hooks.py
+++ b/drf_spectacular/hooks.py
@@ -7,7 +7,8 @@ from rest_framework.settings import api_settings
 
 from drf_spectacular.drainage import warn
 from drf_spectacular.plumbing import (
-    ResolvedComponent, list_hash, load_enum_name_overrides, safe_ref,
+    ResolvedComponent, apply_enum_suffix, build_choices_class_name_overrides, list_hash,
+    load_enum_name_overrides, safe_ref,
 )
 from drf_spectacular.settings import spectacular_settings
 
@@ -59,10 +60,17 @@ def postprocess_schema_enums(result, generator, **kwargs):
 
     schemas = result.get('components', {}).get('schemas', {})
 
-    overrides = load_enum_name_overrides()
+    explicit_overrides = load_enum_name_overrides()
+    use_class_names = spectacular_settings.ENUM_NAME_FROM_CLASS
 
     prop_hash_mapping = defaultdict(set)
     hash_name_mapping = defaultdict(set)
+    # class names captured at the source (x-spec-enum-name, set in resolve_type_hint for
+    # type-hinted enums). hash -> name, conflicts dropped below.
+    captured_class_names: dict = {}
+    captured_conflicts = set()
+    # all captured names per hash, so the ambiguity warning can name the culprits.
+    captured_names_by_hash = defaultdict(set)
     # collect all enums, their names and choice sets
     for component_name, props in iter_prop_containers(schemas):
         for prop_name, prop_schema in props.items():
@@ -74,6 +82,54 @@ def postprocess_schema_enums(result, generator, **kwargs):
             prop_enum_cleaned_hash = extract_hash(prop_schema)
             prop_hash_mapping[prop_name].add(prop_enum_cleaned_hash)
             hash_name_mapping[prop_enum_cleaned_hash].add((component_name, prop_name))
+
+            if use_class_names and prop_schema.get('x-spec-enum-name'):
+                name = apply_enum_suffix(prop_schema['x-spec-enum-name'])
+                captured_names_by_hash[prop_enum_cleaned_hash].add(name)
+                if captured_class_names.get(prop_enum_cleaned_hash, name) != name:
+                    captured_conflicts.add(prop_enum_cleaned_hash)
+                else:
+                    captured_class_names[prop_enum_cleaned_hash] = name
+
+    if use_class_names:
+        # drop captured names that are ambiguous: same values, different class names
+        for enum_hash in captured_conflicts:
+            captured_class_names.pop(enum_hash, None)
+            names = ', '.join(sorted(captured_names_by_hash[enum_hash]))
+            warn(
+                f'ENUM_NAME_FROM_CLASS could not name an enum: differently named enum '
+                f'classes ({names}) share an identical value set. Falling back to field name '
+                f'resolution; add an entry to ENUM_NAME_OVERRIDES to disambiguate.'
+            )
+        # merge auto-derived sources (field-backed registry < captured name), then explicit
+        # ENUM_NAME_OVERRIDES on top. explicit always wins.
+        overrides = {
+            **build_choices_class_name_overrides(),
+            **captured_class_names,
+            **explicit_overrides,
+        }
+        # two value sets resolving to one name would silently collapse into a single component.
+        # drop the colliding entries so they fall back to field-name resolution, but keep explicit
+        # overrides (they win). warn only for purely auto-derived collisions. explicit-vs-explicit
+        # is left to the user, same as without this setting.
+        hashes_by_name = defaultdict(set)
+        for enum_hash, name in overrides.items():
+            hashes_by_name[name].add(enum_hash)
+        for name, hashes in hashes_by_name.items():
+            if len(hashes) <= 1:
+                continue
+            explicit_hashes = {h for h in hashes if explicit_overrides.get(h) == name}
+            for enum_hash in hashes - explicit_hashes:  # auto-derived entries yield; explicit kept
+                overrides.pop(enum_hash, None)
+            if not explicit_hashes:
+                warn(
+                    f'ENUM_NAME_FROM_CLASS could not name an enum: multiple enum '
+                    f'classes resolve to the name "{name}" for distinct value sets. Falling '
+                    f'back to field name resolution; add an entry to ENUM_NAME_OVERRIDES to '
+                    f'disambiguate.'
+                )
+    else:
+        overrides = explicit_overrides
 
     # get the suffix to be used for enums from settings
     enum_suffix = spectacular_settings.ENUM_SUFFIX
@@ -132,7 +188,10 @@ def postprocess_schema_enums(result, generator, **kwargs):
 
             # split property into remaining property and enum component parts
             enum_schema = {k: v for k, v in prop_schema.items() if k in ['type', 'enum']}
-            prop_schema = {k: v for k, v in prop_schema.items() if k not in ['type', 'enum', 'x-spec-enum-id']}
+            prop_schema = {
+                k: v for k, v in prop_schema.items()
+                if k not in ['type', 'enum', 'x-spec-enum-id', 'x-spec-enum-name']
+            }
 
             # separate actual description from name-value tuples
             if spectacular_settings.ENUM_GENERATE_CHOICE_DESCRIPTION:
@@ -180,13 +239,14 @@ def postprocess_schema_enums(result, generator, **kwargs):
 def postprocess_schema_enum_id_removal(result, generator, **kwargs):
     """
     Iterative modifying approach to scanning the whole schema and removing the
-    temporary helper ids that allowed us to distinguish similar enums.
+    temporary helper fields (x-spec-enum-id / x-spec-enum-name) that allowed us to
+    distinguish and name similar enums.
     """
     def clean(sub_result):
         if isinstance(sub_result, dict):
             for key in list(sub_result):
-                if key == 'x-spec-enum-id':
-                    del sub_result['x-spec-enum-id']
+                if key in ('x-spec-enum-id', 'x-spec-enum-name'):
+                    del sub_result[key]
                 else:
                     clean(sub_result[key])
         elif isinstance(sub_result, (list, tuple)):

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -944,6 +944,51 @@ def _load_enum_name_overrides(language: str):
     return overrides
 
 
+def apply_enum_suffix(name):
+    """append ENUM_SUFFIX to a class-derived name unless already present, so class-derived
+    names match field-derived ones (PaymentType -> PaymentTypeEnum)."""
+    suffix = spectacular_settings.ENUM_SUFFIX
+    if suffix and not name.endswith(suffix):
+        return f'{name}{suffix}'
+    return name
+
+
+def build_choices_class_name_overrides():
+    """map value-set hash -> class name for each Choices subclass, using the same hash
+    build_choice_field injects as x-spec-enum-id. the field-backed fallback for naming an enum
+    after its class (ChoiceField drops the class; type-hinted enums use x-spec-enum-name
+    instead). same values under different class names are skipped with a warning."""
+    by_hash: DefaultDict[str, set] = defaultdict(set)
+
+    def visit(cls):
+        for sub in cls.__subclasses__():
+            visit(sub)
+            try:
+                pairs = [(value, label) for value, label in sub.choices if value not in ('', None)]
+            except Exception:
+                continue  # base classes without members, or non-standard choices
+            if pairs:
+                by_hash[list_hash(pairs)].add(sub)
+
+    visit(Choices)
+
+    # same values under multiple class names is dropped here; the mirror case (same name,
+    # different values) is handled on the merged map in postprocess_schema_enums.
+    overrides = {}
+    for enum_hash, classes in by_hash.items():
+        names = {cls.__name__ for cls in classes}
+        if len(names) == 1:
+            overrides[enum_hash] = apply_enum_suffix(next(iter(names)))
+        else:
+            qualified = ', '.join(sorted(f'{c.__module__}.{c.__qualname__}' for c in classes))
+            warn(
+                f'ENUM_NAME_FROM_CLASS could not name an enum: multiple Choices '
+                f'classes share an identical value set ({qualified}). Falling back to field '
+                f'name resolution; add an entry to ENUM_NAME_OVERRIDES to disambiguate.'
+            )
+    return overrides
+
+
 def list_hash(lst: Any) -> str:
     return hashlib.sha256(json.dumps(sorted(lst), sort_keys=True, cls=JSONEncoder).encode()).hexdigest()[:16]
 
@@ -1399,6 +1444,10 @@ def resolve_type_hint(hint):
             if spectacular_settings.ENUM_GENERATE_CHOICE_DESCRIPTION:
                 schema['description'] = build_choice_description_list(hint.choices)
             schema['x-spec-enum-id'] = list_hash([(k, v) for k, v in hint.choices if k not in ('', None)])
+        # remember the class name so ENUM_NAME_FROM_CLASS can name the component after it.
+        # covers any Enum reached via a type hint; the field-backed path loses the class and
+        # falls back to build_choices_class_name_overrides instead.
+        schema['x-spec-enum-name'] = hint.__name__
         return schema
     elif isinstance(hint, TYPED_DICT_META_TYPES):
         return _resolve_typeddict(hint)

--- a/drf_spectacular/plumbing.py
+++ b/drf_spectacular/plumbing.py
@@ -965,7 +965,7 @@ def build_choices_class_name_overrides():
             visit(sub)
             try:
                 pairs = [(value, label) for value, label in sub.choices if value not in ('', None)]
-            except Exception:
+            except Exception:  # pragma: no cover
                 continue  # base classes without members, or non-standard choices
             if pairs:
                 by_hash[list_hash(pairs)].add(sub)

--- a/drf_spectacular/settings.py
+++ b/drf_spectacular/settings.py
@@ -116,6 +116,11 @@ SPECTACULAR_DEFAULTS: Dict[str, Any] = {
     # enum name overrides. dict with keys "YourEnum" and their choice values "field.choices"
     # e.g. {'SomeEnum': ['A', 'B'], 'OtherEnum': 'import.path.to.choices'}
     'ENUM_NAME_OVERRIDES': {},
+    # Name enum components after the Choices/Enum class that backs them, rather than the
+    # referencing field (like components are named after their serializer). Type-hinted enums use
+    # their class directly; field-backed choices are matched to a Choices subclass by value set.
+    # Explicit ENUM_NAME_OVERRIDES win; ambiguous classes fall back to field names (with a warning).
+    'ENUM_NAME_FROM_CLASS': False,
     # Adds "blank" and "null" enum choices where appropriate. disable on client generation issues
     'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': True,
     # Add/Append a list of (``choice value`` - choice name) to the enum description string.

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -174,10 +174,10 @@ TYPE_HINT_TEST_PARAMS = [
         {'oneOf': [{'type': 'string'}, {'type': 'integer'}], 'nullable': True}
     ), (
         LanguageEnum,
-        {'enum': ['en', 'de'], 'type': 'string'}
+        {'enum': ['en', 'de'], 'type': 'string', 'x-spec-enum-name': 'LanguageEnum'}
     ), (
         InvalidLanguageEnum,
-        {'enum': ['en', 'de']}
+        {'enum': ['en', 'de'], 'x-spec-enum-name': 'InvalidLanguageEnum'}
     ), (
         NamedTupleB,
         {
@@ -202,7 +202,8 @@ if DJANGO_VERSION > '3':
             'enum': ['en', 'de'],
             'type': 'string',
             'description': '* `en` - En\n* `de` - De',
-            'x-spec-enum-id': '982ab9eaa2725610'
+            'x-spec-enum-id': '982ab9eaa2725610',
+            'x-spec-enum-name': 'LanguageChoices'
         }
     ))
 

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -240,6 +240,28 @@ def test_enum_name_from_integer_choices_class(capsys, clear_caches):
     assert 'PriorityLevelChoices' not in capsys.readouterr().err  # not flagged ambiguous
 
 
+class GaugeEnum(TextChoices):
+    # class name already ends in ENUM_SUFFIX; distinctive values keep the set unique
+    LOW = 'gauge_low', 'Low'
+    HIGH = 'gauge_high', 'High'
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_choices_class_no_double_suffix(clear_caches):
+    class XSerializer(serializers.Serializer):
+        level = serializers.ChoiceField(choices=GaugeEnum.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    # class name already ends in ENUM_SUFFIX, so it is used as-is, not "GaugeEnumEnum"
+    assert 'GaugeEnum' in schemas['X']['properties']['level']['$ref']
+    assert 'GaugeEnumEnum' not in schemas
+    assert 'LevelEnum' not in schemas
+
+
 @mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
 @mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {
     'Shade': 'tests.test_postprocessing.ColorChoices'

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,5 +1,6 @@
+import json
 import typing
-from enum import Enum
+from enum import Enum, IntEnum, IntFlag
 from unittest import mock
 
 import pytest
@@ -16,7 +17,7 @@ except ImportError:
     IntegerChoices = object  # type: ignore  # django < 3.0 handling
 
 from drf_spectacular.plumbing import _load_enum_name_overrides, list_hash, load_enum_name_overrides
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from tests import assert_schema, generate_schema
 
 language_choices = (
@@ -189,6 +190,338 @@ def test_global_enum_naming_override_with_blank_and_none(no_warnings, clear_cach
         '#/components/schemas/BlankEnum',
         '#/components/schemas/NullEnum'
     ]
+
+
+class ColorChoices(TextChoices):
+    # deliberately distinctive values so the set is unique across the test process
+    CRIMSON = 'clr_crimson', 'Crimson'
+    AZURE = 'clr_azure', 'Azure'
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_choices_class(capsys, clear_caches):
+    class XSerializer(serializers.Serializer):
+        # field name differs from the backing Choices class on purpose
+        kind = serializers.ChoiceField(choices=ColorChoices.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    # component is named after the Choices class (+ ENUM_SUFFIX), not the field "kind"
+    assert 'ColorChoicesEnum' in schema['components']['schemas']['X']['properties']['kind']['$ref']
+    assert 'ColorChoicesEnum' in schema['components']['schemas']
+    assert 'KindEnum' not in schema['components']['schemas']
+    assert 'ColorChoices' not in capsys.readouterr().err  # not flagged ambiguous
+
+
+class PriorityLevelChoices(IntegerChoices):
+    # distinctive integer values so the set is unique across the test process
+    LOW = 11, 'Low'
+    HIGH = 99, 'High'
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_integer_choices_class(capsys, clear_caches):
+    class XSerializer(serializers.Serializer):
+        # field name differs from the backing IntegerChoices class on purpose
+        rank = serializers.ChoiceField(choices=PriorityLevelChoices.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    # component is named after the IntegerChoices class (+ ENUM_SUFFIX), not the field "rank"
+    enum = schema['components']['schemas']['PriorityLevelChoicesEnum']
+    assert 'PriorityLevelChoicesEnum' in schema['components']['schemas']['X']['properties']['rank']['$ref']
+    assert 'RankEnum' not in schema['components']['schemas']
+    assert enum['type'] == 'integer'
+    assert enum['enum'] == [11, 99]
+    assert 'PriorityLevelChoices' not in capsys.readouterr().err  # not flagged ambiguous
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {
+    'Shade': 'tests.test_postprocessing.ColorChoices'
+})
+def test_enum_name_from_choices_class_explicit_override_wins(clear_caches):
+    class XSerializer(serializers.Serializer):
+        kind = serializers.ChoiceField(choices=ColorChoices.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    # explicit ENUM_NAME_OVERRIDES takes precedence over the auto class-derived name
+    assert 'Shade' in schema['components']['schemas']['X']['properties']['kind']['$ref']
+    assert 'ColorChoicesEnum' not in schema['components']['schemas']
+
+
+explicit_clash_choices = [('xclash_1', 'One'), ('xclash_2', 'Two')]
+
+
+class GadgetEnumChoices(TextChoices):
+    # class-derived name (+ suffix) collides with the explicit override name below, but for a
+    # different value set; distinctive values keep the set unique across the test process
+    SPROCKET = 'gdg_sprocket', 'Sprocket'
+    WIDGET = 'gdg_widget', 'Widget'
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_OVERRIDES', {
+    # explicit name equals the class-derived name (GadgetEnumChoices -> GadgetEnumChoicesEnum)
+    # but maps a different value set
+    'GadgetEnumChoicesEnum': 'tests.test_postprocessing.explicit_clash_choices'
+})
+def test_enum_name_from_choices_class_explicit_collision_auto_yields(capsys, clear_caches):
+    class XSerializer(serializers.Serializer):
+        explicit_field = serializers.ChoiceField(choices=explicit_clash_choices)
+        auto_field = serializers.ChoiceField(choices=GadgetEnumChoices.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    props = schemas['X']['properties']
+    # explicit override keeps the contested name; the auto-derived class yields to field-name
+    assert 'GadgetEnumChoicesEnum' in props['explicit_field']['$ref']
+    assert schemas['GadgetEnumChoicesEnum']['enum'] == ['xclash_1', 'xclash_2']
+    assert 'AutoFieldEnum' in props['auto_field']['$ref']
+    assert schemas['AutoFieldEnum']['enum'] == ['gdg_sprocket', 'gdg_widget']
+    # yielding to an explicit override is a clean resolution, not the ambiguous-warning case:
+    # the contested name is not the subject of a warning (other unrelated enums may warn)
+    assert 'GadgetEnumChoicesEnum' not in capsys.readouterr().err
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_choices_class_ambiguous_falls_back(capsys, clear_caches):
+    # two distinct Choices classes with an identical value set; defined locally so they are
+    # garbage-collected (and drop out of __subclasses__) after this test
+    class AmbiguousAChoices(TextChoices):
+        X = 'ambig_x', 'X'
+        Y = 'ambig_y', 'Y'
+
+    class AmbiguousBChoices(TextChoices):
+        X = 'ambig_x', 'X'
+        Y = 'ambig_y', 'Y'
+
+    class XSerializer(serializers.Serializer):
+        kind = serializers.ChoiceField(choices=AmbiguousAChoices.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    stderr = capsys.readouterr().err
+    # the shared value set is ambiguous -> warn and fall back to field-name resolution
+    assert 'could not name an enum' in stderr
+    assert 'KindEnum' in schema['components']['schemas']
+    assert any(n in stderr for n in ('AmbiguousAChoices', 'AmbiguousBChoices'))
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_choices_class_name_collision_falls_back(capsys, clear_caches):
+    # two classes sharing a __name__ but different values (as across apps) would collapse into
+    # one component, so neither claims the name. local so they are GC'd after the test.
+    # functional API takes (member_name, value) pairs; values deliberately distinctive
+    NameClashA = TextChoices('SameNameChoices', [('CA1', 'clash_a1'), ('CA2', 'clash_a2')])
+    NameClashB = TextChoices('SameNameChoices', [('CB1', 'clash_b1'), ('CB2', 'clash_b2')])
+
+    class XSerializer(serializers.Serializer):
+        # distinct field names so the fallback yields two distinct, correct components
+        alpha = serializers.ChoiceField(choices=NameClashA.choices)
+        beta = serializers.ChoiceField(choices=NameClashB.choices)
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    stderr = capsys.readouterr().err
+    # collision detected -> warn and fall back; neither enum collapses into the other
+    assert 'could not name an enum' in stderr
+    assert 'SameNameChoicesEnum' not in schemas
+    assert schemas['AlphaEnum']['enum'] == ['clash_a1', 'clash_a2']
+    assert schemas['BetaEnum']['enum'] == ['clash_b1', 'clash_b2']
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_native_enum_name_collision_falls_back(capsys, clear_caches):
+    # same as the collision test above, but via the type-hint capture path: two native enums
+    # sharing a __name__ with different values must not collapse into one component.
+    NativeClashA = Enum('SharedName', [('A1', 'native_a1'), ('A2', 'native_a2')])
+    NativeClashB = Enum('SharedName', [('B1', 'native_b1'), ('B2', 'native_b2')])
+
+    class XSerializer(serializers.Serializer):
+        alpha = serializers.SerializerMethodField()
+        beta = serializers.SerializerMethodField()
+
+        @extend_schema_field(NativeClashA)
+        def get_alpha(self, obj):
+            return 'native_a1'  # pragma: no cover
+
+        @extend_schema_field(NativeClashB)
+        def get_beta(self, obj):
+            return 'native_b1'  # pragma: no cover
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    stderr = capsys.readouterr().err
+    assert 'could not name an enum' in stderr
+    assert 'SharedNameEnum' not in schemas
+    assert schemas['AlphaEnum']['enum'] == ['native_a1', 'native_a2']
+    assert schemas['BetaEnum']['enum'] == ['native_b1', 'native_b2']
+
+
+class NativeSuit(Enum):
+    # native enum.Enum reached via a type hint; distinctive values, field name will differ
+    HEART = 'native_heart'
+    SPADE = 'native_spade'
+
+
+class NativePriorityRank(IntEnum):
+    # native enum.IntEnum reached via a type hint; distinctive values
+    LOW = 4101
+    HIGH = 4109
+
+
+class NativeAccessFlag(IntFlag):
+    # native enum.IntFlag reached via a type hint; bitwise (power-of-two) values
+    READ = 4096
+    WRITE = 8192
+    EXECUTE = 16384
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_native_enum_via_type_hint(capsys, clear_caches):
+    class XSerializer(serializers.Serializer):
+        suit = serializers.SerializerMethodField()  # field name != class name
+
+        @extend_schema_field(NativeSuit)
+        def get_suit(self, obj):
+            return 'native_heart'  # pragma: no cover
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    suit = schemas['X']['properties']['suit']
+    ref = suit.get('$ref') or suit['allOf'][0]['$ref']  # read-only method field wraps in allOf
+    # named after the native Enum class captured at the source (x-spec-enum-name), not field "suit"
+    assert 'NativeSuitEnum' in ref
+    assert 'NativeSuitEnum' in schemas
+    assert 'SuitEnum' not in schemas
+    # the x-spec-enum-name helper must never leak into the emitted schema
+    assert 'x-spec-enum-name' not in json.dumps(schema)
+    assert 'NativeSuit' not in capsys.readouterr().err  # not flagged ambiguous
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_native_int_enum_via_type_hint(clear_caches):
+    class XSerializer(serializers.Serializer):
+        rank = serializers.SerializerMethodField()  # field name != class name
+
+        @extend_schema_field(NativePriorityRank)
+        def get_rank(self, obj):
+            return 4101  # pragma: no cover
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    enum = schemas['NativePriorityRankEnum']
+    rank = schemas['X']['properties']['rank']
+    ref = rank.get('$ref') or rank['allOf'][0]['$ref']  # read-only method field wraps in allOf
+    assert 'NativePriorityRankEnum' in ref
+    assert 'RankEnum' not in schemas
+    assert enum['type'] == 'integer'
+    assert enum['enum'] == [4101, 4109]
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_native_int_flag_via_type_hint(clear_caches):
+    # IntFlag is an Enum subclass, so it flows through the same capture path; pin that the
+    # individual (bitwise, power-of-two) member values are enumerated and integer-typed
+    class XSerializer(serializers.Serializer):
+        access = serializers.SerializerMethodField()  # field name != class name
+
+        @extend_schema_field(NativeAccessFlag)
+        def get_access(self, obj):
+            return 4096  # pragma: no cover
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    enum = schemas['NativeAccessFlagEnum']
+    access = schemas['X']['properties']['access']
+    ref = access.get('$ref') or access['allOf'][0]['$ref']  # read-only method field wraps in allOf
+    # named after the IntFlag class, not the field "access"
+    assert 'NativeAccessFlagEnum' in ref
+    assert 'AccessEnum' not in schemas
+    assert enum['type'] == 'integer'
+    # the member values themselves are enumerated (bitwise combinations are not)
+    assert enum['enum'] == [4096, 8192, 16384]
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', True)
+def test_enum_name_from_native_enum_ambiguous_falls_back(capsys, clear_caches):
+    # two native enums with the same values but different names, via the type-hint capture path.
+    # they cannot be told apart by value, so the name is dropped and the warning names both.
+    NativeAmbigA = Enum('NativeAmbigA', [('M1', 'ambig_native_1'), ('M2', 'ambig_native_2')])
+    NativeAmbigB = Enum('NativeAmbigB', [('M1', 'ambig_native_1'), ('M2', 'ambig_native_2')])
+
+    class XSerializer(serializers.Serializer):
+        alpha = serializers.SerializerMethodField()
+        beta = serializers.SerializerMethodField()
+
+        @extend_schema_field(NativeAmbigA)
+        def get_alpha(self, obj):
+            return 'ambig_native_1'  # pragma: no cover
+
+        @extend_schema_field(NativeAmbigB)
+        def get_beta(self, obj):
+            return 'ambig_native_1'  # pragma: no cover
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    stderr = capsys.readouterr().err
+    # ambiguous shared value set -> warn (naming both culprits) and fall back to field names
+    assert 'could not name an enum' in stderr
+    assert 'NativeAmbigAEnum' in stderr and 'NativeAmbigBEnum' in stderr
+    assert 'AlphaEnum' in schemas and 'BetaEnum' in schemas
+
+
+@mock.patch('drf_spectacular.settings.spectacular_settings.ENUM_NAME_FROM_CLASS', False)
+def test_enum_name_from_class_disabled_keeps_field_name(clear_caches):
+    # with the setting off, naming is unchanged (field-derived) and no helper field leaks
+    class XSerializer(serializers.Serializer):
+        suit = serializers.SerializerMethodField()
+
+        @extend_schema_field(NativeSuit)
+        def get_suit(self, obj):
+            return 'native_heart'  # pragma: no cover
+
+    class XView(generics.RetrieveAPIView):
+        serializer_class = XSerializer
+
+    schema = generate_schema('/x', view=XView)
+    schemas = schema['components']['schemas']
+    suit = schemas['X']['properties']['suit']
+    ref = suit.get('$ref') or suit['allOf'][0]['$ref']  # read-only method field wraps in allOf
+    assert 'SuitEnum' in ref
+    assert 'NativeSuitEnum' not in schemas
+    assert 'x-spec-enum-name' not in json.dumps(schema)
 
 
 def test_enum_name_reuse_warning(capsys):


### PR DESCRIPTION
Adds an opt-in `ENUM_NAME_FROM_CLASS` setting that names enum components after the `Choices`/`Enum` class backing them instead of the field that references them.

Right now enums get named after the field, and if you want something else you list every one in `ENUM_NAME_OVERRIDES`. That couples the component name to the field name (rename a field, the schema churns) and it's a lot of manual bookkeeping once you have more than a handful. This makes naming work the same way it already does for serializers, where the component is named after the class.

So with the setting on:

```python
class Color(models.TextChoices):
    CRIMSON = 'crimson', 'Crimson'
    AZURE = 'azure', 'Azure'

class XSerializer(serializers.Serializer):
    field = serializers.ChoiceField(choices=Color.choices)
```

you get `ColorEnum` instead of `FieldEnum`. Same for an enum reached through a type hint (e.g. a `SerializerMethodField` with `@extend_schema_field(NativeSuit)`), which becomes `NativeSuitEnum`. Explicit `ENUM_NAME_OVERRIDES` still win.

The annoying part is that a DRF `ChoiceField` only keeps the choice values and labels, not the class, so finding the class name needs two paths:

- For type-hinted enums I grab the name at the source in `resolve_type_hint` and stash it on a new `x-spec-enum-name` helper (works for native `Enum`/`IntEnum`/`IntFlag` and `Choices`). It gets read back in post-processing and stripped out, same as `x-spec-enum-id`.
- For field-backed `Choices` there's no class to grab, so I match the choices back to a `Choices` subclass by value set, reusing the hash `build_choice_field` already injects.

Precedence ends up being: field-backed match < type-hint capture < explicit overrides.

Defaults to `False`, so nothing changes unless you turn it on, and the helper field never shows up in the output.

A few cases can't be resolved automatically. Each one warns and falls back to the old field-name naming:

- a plain `Enum` used directly as field choices only gets named after its class if it's also reached through a type hint (the field drops the class, and a plain `Enum` isn't in the `Choices` registry to match against)
- two different classes with the exact same choices, since there's nothing to tell them apart by
- two different classes that share a name but have different choices, since naming both after the class would merge them into one component

In all of those you can add an `ENUM_NAME_OVERRIDES` entry to sort it out.

Tests cover both paths, the three fallbacks, override precedence, suffix handling, and the off-by-default no-op. Docs added to `docs/faq.rst`.
