### PR TITLE
Security: Potential XSS via Template Rendering with |safe Filter

### DIFF
--- a/drf_spectacular/templates/drf_spectacular/redoc.html
+++ b/drf_spectacular/templates/drf_spectacular/redoc.html
@@ -19,8 +19,9 @@
     {% if settings %}
     <div id="redoc-container"></div>
     <script src="{{ redoc_standalone }}"></script>
+    {{ settings|json_script:"redoc-settings" }}
     <script>
-      const redocSettings = {{ settings|safe }};
+      const redocSettings = JSON.parse(document.getElementById('redoc-settings').textContent);
       Redoc.init("{{ schema_url }}", redocSettings, document.getElementById('redoc-container'))
     </script>
     {% else %}


### PR DESCRIPTION
## Summary

Security: Potential XSS via Template Rendering with |safe Filter

## Problem

**Severity**: `Medium` | **File**: `drf_spectacular/templates/drf_spectacular/redoc.html:L22`

In drf_spectacular/templates/drf_spectacular/redoc.html, the template uses {{ settings|safe }} which marks the content as safe HTML. If 'settings' contains user-controlled or attacker-influenced data, this could lead to Cross-Site Scripting (XSS). Similarly, in drf_spectacular/templates/drf_spectacular/swagger_ui.html, {% include template_name_js %} and in swagger_ui.js, {{ settings|safe }} and {{ schema_auth_names|safe }} are used. The 'safe' filter bypasses Django's auto-escaping. If any of these variables contain untrusted input, XSS is possible.

## Solution

Ensure that 'settings' and other variables marked with |safe are properly sanitized and do not contain user-controlled data. Consider using json_script filter or explicit JSON serialization with proper escaping instead of marking raw content as safe.

## Changes

- `drf_spectacular/templates/drf_spectacular/redoc.html` (modified)